### PR TITLE
fix(subghz): Reset modulation to prevent freeze

### DIFF
--- a/applications/main/subghz/scenes/subghz_scene_frequency_analyzer.c
+++ b/applications/main/subghz/scenes/subghz_scene_frequency_analyzer.c
@@ -71,6 +71,7 @@ bool subghz_scene_frequency_analyzer_on_event(void* context, SceneManagerEvent e
         } else if(event.event == SubGhzCustomEventViewFreqAnalOkLong) {
             // Don't need to save, we already saved on short event (and on exit event too)
             subghz_rx_key_state_set(subghz, SubGhzRxKeyStateIDLE);
+            subghz_txrx_set_default_preset(subghz->txrx);
             scene_manager_previous_scene(subghz->scene_manager); // Stops the worker
             scene_manager_next_scene(subghz->scene_manager, SubGhzSceneReceiver);
             return true;


### PR DESCRIPTION
Resets the modulation to the default preset before transitioning from the frequency analyzer to the receiver scene. This prevents the app from freezing when a signal with FM238 modulation is selected.

# What's new

- [Describe changes here]

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
