### PR TITLE
fix: BLE remote name + NFC/toolbox improvements

### DIFF
--- a/lib/ble_profile/extra_profiles/hid_profile.c
+++ b/lib/ble_profile/extra_profiles/hid_profile.c
@@ -413,7 +413,7 @@ static void ble_profile_hid_get_config(GapConfig* config, FuriHalBleProfileParam
     }
 
     // Set advertise name
-    const char* clicker_str = "Control";
+    const char* clicker_str = "Remote";
     if(hid_profile_params && hid_profile_params->device_name_prefix) {
         clicker_str = hid_profile_params->device_name_prefix;
     }

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
@@ -342,7 +342,8 @@ static Iso15693_3Error iso15693_3_listener_write_multi_blocks_handler(
         if(error != Iso15693_3ErrorNone) break;
 
         for(uint32_t i = block_index_start; i < block_count + request->first_block_num; ++i) {
-            const uint8_t* block_data = &request->block_data[block_size * i];
+            const uint32_t block_offset = i - block_index_start;
+            const uint8_t* block_data = &request->block_data[block_size * block_offset];
             iso15693_3_set_block_data(instance->data, i, block_data, block_size);
         }
     } while(false);

--- a/lib/nfc/protocols/mf_desfire/mf_desfire.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire.c
@@ -135,19 +135,23 @@ bool mf_desfire_load(MfDesfireData* data, FlipperFormat* ff, uint32_t version) {
             break;
 
         const uint32_t master_key_version_count = data->master_key_settings.max_keys;
-        simple_array_init(data->master_key_versions, master_key_version_count);
+        if(master_key_version_count > 0) {
+            simple_array_init(data->master_key_versions, master_key_version_count);
 
-        uint32_t i;
-        for(i = 0; i < master_key_version_count; ++i) {
-            if(!mf_desfire_key_version_load(
-                   simple_array_get(data->master_key_versions, i),
-                   MF_DESFIRE_FFF_PICC_PREFIX,
-                   i,
-                   ff))
-                break;
+            uint32_t i;
+            for(i = 0; i < master_key_version_count; ++i) {
+                if(!mf_desfire_key_version_load(
+                       simple_array_get(data->master_key_versions, i),
+                       MF_DESFIRE_FFF_PICC_PREFIX,
+                       i,
+                       ff))
+                    break;
+            }
+
+            if(i != master_key_version_count) break;
+        } else {
+            simple_array_reset(data->master_key_versions);
         }
-
-        if(i != master_key_version_count) break;
 
         uint32_t application_count;
         if(!mf_desfire_application_count_load(&application_count, ff)) break;

--- a/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
+++ b/lib/nfc/protocols/mf_desfire/mf_desfire_poller_i.c
@@ -161,7 +161,11 @@ MfDesfireError mf_desfire_poller_read_key_versions(
     SimpleArray* data,
     uint32_t count) {
     furi_check(instance);
-    furi_check(count > 0);
+    furi_check(data);
+    if(count == 0) {
+        simple_array_reset(data);
+        return MfDesfireErrorNone;
+    }
 
     simple_array_init(data, count);
 

--- a/lib/toolbox/simple_array.c
+++ b/lib/toolbox/simple_array.c
@@ -11,6 +11,8 @@ struct SimpleArray {
 SimpleArray* simple_array_alloc(const SimpleArrayConfig* config) {
     SimpleArray* instance = malloc(sizeof(SimpleArray));
     instance->config = config;
+    instance->data = NULL;
+    instance->count = 0;
     return instance;
 }
 


### PR DESCRIPTION
Closes #45
Closes #64

Multiple improvements from AI automation:

## BLE Profile (Issue #45)
- Changed default BLE advertise name from 'Control' to 'Remote'
- Improves device recognition and user experience

## NFC Fixes (Issue #64)
- Fixed Desfire poller furi_check failures
- Improved ISO15693-3 listener implementation
- Enhanced MF Desfire protocol handling

## Toolbox
- Fixed simple_array memory management
- Improved error handling

**Auto-generated by Gemini + Codex**