### PR TITLE
chore: auto-import upstream issues from flipperdevices/flipperzero-firmware

### DIFF
--- a/.ai/upstream-issues/01038-feature-request--i2c-and-spi-bridge-to-usb.md
+++ b/.ai/upstream-issues/01038-feature-request--i2c-and-spi-bridge-to-usb.md
@@ -1,0 +1,13 @@
+# Issue #1038: Feature Request: i2c and SPI bridge to USB
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1038](https://github.com/flipperdevices/flipperzero-firmware/issues/1038)
+**Author:** @Patronics
+**Created:** 2022-03-17T22:59:03Z
+**Labels:** Feature Request, Applications
+
+## Description
+
+Similarly to the USB-UART bridge, it'd be really useful to have an option to use flipper as a i2c device (Ideally both as a master and a slave that shares the memory to the host computer). Similarly a SPI Bridge option would be useful. 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01040-feature-request--twin-duck-usb-rubber-ducky-emul.md
+++ b/.ai/upstream-issues/01040-feature-request--twin-duck-usb-rubber-ducky-emul.md
@@ -1,0 +1,13 @@
+# Issue #1040: Feature Request: "Twin Duck" usb rubber ducky emulation
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1040](https://github.com/flipperdevices/flipperzero-firmware/issues/1040)
+**Author:** @Patronics
+**Created:** 2022-03-17T23:06:23Z
+**Labels:** Feature Request, USB
+
+## Description
+
+Many of the sample badusb scripts from Hak5 use the "Twin Duck" firmware, emulating a USB drive in addition to a keyboard input. This would add a lot more flexibility to the BadUSB feature.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01158-power-option-to-reduce-charging-limit-for-increa.md
+++ b/.ai/upstream-issues/01158-power-option-to-reduce-charging-limit-for-increa.md
@@ -1,0 +1,52 @@
+# Issue #1158: [Power] Option to reduce charging limit for increased battery longevity
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1158](https://github.com/flipperdevices/flipperzero-firmware/issues/1158)
+**Author:** @digitalcircuit
+**Created:** 2022-04-24T01:28:55Z
+**Labels:** Feature Request, USB, Core+Services
+
+## Description
+
+**Is your feature request related to a problem? Please describe.**
+From what I understand, lithium batteries wear out over time, and [using and storing lithium batteries at full charge (e.g. 4.2v) can result in the battery wearing out faster]( https://batteryuniversity.com/article/bu-808-how-to-prolong-lithium-based-batteries ).
+
+Since the Flipper Zero's battery is not easily replaceable (requires disassembly), I'd like to take steps to ensure it degrades as little as possible when I don't need the full battery capacity.
+
+**Describe the solution you'd like**
+Provide an option in `Settings` → `Power` to reduce the maximum allowed battery charge for sake of battery longevity.
+
+For example, `Charge limit: 100%`, adjustable down to `60%` or so in 10% decrements.
+
+Alternatively, just provide a few charging profiles (`Full Charge`, `Balanced`, `Max Lifespan`) corresponding to 100%, 80%, and 60% or so (see System76's UI in additional context).
+
+*Implementation details:*
+Flipper's firmware currently can [pause charging with `furi_hal_power_suppress_charge_enter()` and `furi_hal_power_suppress_charge_exit()`](https://github.com/flipperdevices/flipperzero-firmware/blob/9351076c89cad62e8a33fd2e809e7e81eaa37fca/firmware/targets/f7/furi_hal/furi_hal_power.c#L409-L433 ).
+
+Alternatively, [it appears there may be a way to adjust the bq25896 regulator's voltage limit via `VREG` in `REG06`](https://github.com/flipperdevices/flipperzero-firmware/blob/2f3ea9494e577dd4c0f0dd2bfa18871476f96c38/lib/drivers/bq25896_reg.h#L101 ).  If feasible, lowering that may avoid requiring having the Flipper firmware actively toggle suppressing the charging circuitry.
+
+Either way, the Desktop UI's battery indicator should probably show that the battery charge is limited to avoid potentially confusing folks.
+
+**Describe alternatives you've considered**
+* Simply unplugging the Flipper Zero before it fully charges
+  * Pros: free, no development effort required
+  * Cons: easy to forget, doesn't work when plugged into a computer for USB features
+* Hardware charge limiting device
+  * Pros: can be automated, no changes to Flipper required
+  * Cons: requires power measuring or coordination with Flipper firmware, needs an extra dongle, may interfere with USB usage
+* Letting Flipper charge to 100% / not caring
+  * Pros: easiest, no changes or effort required, battery replacement is at least possible (screws etc, no glue in assembly)
+  * Cons: may wear out the battery faster through higher charge cycles
+
+**Additional context**
+There's ongoing research around battery charge thresholds and various devices and software exists to control this on other platforms.  It'd be nice if Flipper could integrate this without needing a third-party workaround.
+
+* [Battery University article on prolonging lithium battery lifespan](https://batteryuniversity.com/article/bu-808-how-to-prolong-lithium-based-batteries )
+* [ACC (Advanced Charge Controller) for rooted Android devices](https://github.com/VR-25/acc/#readme )
+* [Chargie hardware charge limiting device](https://chargie.org/ ) for phones and USB devices
+* System76's [battery charging threshold documentation](https://support.system76.com/articles/laptop-battery-thresholds/ ) and [UI implementation in GNOME Control Center](https://github.com/pop-os/gnome-control-center/pull/140#issuecomment-763757743 )
+* Dell provides a charge threshold setting in their laptop UEFI firmware
+* Electric vehicles (Tesla, etc) may have settings for "daily trip" versus "long drive"
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01171-program-multi-key-ir-inputs.md
+++ b/.ai/upstream-issues/01171-program-multi-key-ir-inputs.md
@@ -1,0 +1,36 @@
+# Issue #1171: Program multi-key IR inputs
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1171](https://github.com/flipperdevices/flipperzero-firmware/issues/1171)
+**Author:** @edbrannin
+**Created:** 2022-04-26T20:12:19Z
+**Labels:** Feature Request, Infrared, UI
+
+## Description
+
+**Is your feature request related to a problem? Please describe.**
+
+I'd like to save a sequence of IR signals to replay from the Flipper, like:
+
+- TV Input, TV 2
+- TV power on, Receiver power on, Receiver input X
+
+**Describe the solution you'd like**
+
+Today: When recording a new IR payload, as soon as the Flipper recognizes a signal, it stops listening and prompts to [RETRY, SEND, SAVE].
+
+Maybe add an ADD option to make the Flipper capture a second signal to play after the first?
+
+**Describe alternatives you've considered**
+
+Other options include:
+
+- Crafting macros from the IR app (more flexibility, but there are UX challenges; we can't even reorder custom remote buttons yet)
+- Crafting macros from the Mobile apps (Simpler UX, but requires an additional device for setup)
+- Sending IR-app-recorded signals from a compiled Application (those can't be sideloaded yet, and it would limit this sort of thing to programmers)
+
+**Additional context**
+
+[`u/skotozavr`](https://www.reddit.com/user/skotozavr/) [suggested I report this issue from Reddit](https://www.reddit.com/r/flipperzero/comments/tzy80f/can_you_do_multiplea_series_of_infrared_replays/)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01234-two-dimensional-layout-for-saved-remotes.md
+++ b/.ai/upstream-issues/01234-two-dimensional-layout-for-saved-remotes.md
@@ -1,0 +1,24 @@
+# Issue #1234: Two-dimensional layout for saved remotes
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1234](https://github.com/flipperdevices/flipperzero-firmware/issues/1234)
+**Author:** @lykahb
+**Created:** 2022-05-15T18:43:47Z
+**Labels:** Feature Request, Infrared, UI
+
+## Description
+
+**Is your feature request related to a problem? Please describe.**
+The buttons on a saved remote are displayed as a list. It may take long time to scroll to the needed button.
+
+**Describe the solution you'd like**
+The universal library for TV has a scene with a two-dimensional layout. A saved remote would display a similar layout for the names that it recognizes, and puts the rest in a list below. For example, a saved remote has these commands: POWER, VOL+, VOL-, CH+, CH-, NETFLIX, YOUTUBE. Then we display the first commands as icons in a layout, and put the netflix and youtube in a list below, 
+
+**Describe alternatives you've considered**
+A simpler grid with two columns that have names and no icons. The items are displayed in the same order as in the .ir file, with no mapping to icon or layout position. The names are truncated to fit half width of the screen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01290-rename-liftmaster_3xx-to-security1.0_3xx.md
+++ b/.ai/upstream-issues/01290-rename-liftmaster_3xx-to-security1.0_3xx.md
@@ -1,0 +1,26 @@
+# Issue #1290: Rename LiftMaster_3XX to Security+1.0_3XX
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1290](https://github.com/flipperdevices/flipperzero-firmware/issues/1290)
+**Author:** @xslim
+**Created:** 2022-06-02T00:32:18Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+**Is your feature request related to a problem? Please describe.**
+While Reading the Sub-GHz codes from Remote, I see Security+1.0.
+But when I try to create a remote Manually, it is not there. 
+Digging thru source code, I see that LiftMaster is a Security+1.0.
+
+**Describe the solution you'd like**
+I would like to see a Security+1.0 in Add Manual menu, as it is more generic, and not only related to garage opener.
+
+**Describe alternatives you've considered**
+Alternative: Add Security+1.0 in addition to LiftMaster, but than we are just adding duplicated entries.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01468-nfc-emulation-of-previously-saved-mifare-classic-1.md
+++ b/.ai/upstream-issues/01468-nfc-emulation-of-previously-saved-mifare-classic-1.md
@@ -1,0 +1,39 @@
+# Issue #1468: NFC Emulation of previously saved Mifare classic 1k card does not work.
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1468](https://github.com/flipperdevices/flipperzero-firmware/issues/1468)
+**Author:** @bolmar3
+**Created:** 2022-07-27T17:28:13Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+I have multiple saved cards from 0.62.1, and in the latest release candidate, when I emulate the card, my phone cannot detect it at all. When I emulate a saved NTAG/Ultralight there is no issue.
+
+### Reproduction
+
+On 0.62, save a Mifare classic 1k card
+Update to RC
+NFC->Saved->saved card->Emulate
+Phone cannot detect emulated card
+
+### Target
+
+e28446de49db99093c33dd43a1c4773d94e35942 (release-candidate)
+
+### Logs
+
+```Text
+This is for a wifi tag I had: https://pastebin.com/R8s1gY2L
+
+And this is for a contact (VCARD) mifare classic 1k card: https://pastebin.com/vA5HdcwK
+```
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01534-hitag2-support.md
+++ b/.ai/upstream-issues/01534-hitag2-support.md
@@ -1,0 +1,23 @@
+# Issue #1534: Hitag2 Support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1534](https://github.com/flipperdevices/flipperzero-firmware/issues/1534)
+**Author:** @eben80
+**Created:** 2022-08-04T08:29:38Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Would it be possible to support Hitag2 tags under the 125kHz RFID function?
+
+I'm not sure if the [code](https://github.com/Proxmark/proxmark3/blob/master/armsrc/hitag2.c) in this project would be of any help.
+
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01556-subghz-read-and-read-raw-to-retain-configs-after-e.md
+++ b/.ai/upstream-issues/01556-subghz-read-and-read-raw-to-retain-configs-after-e.md
@@ -1,0 +1,28 @@
+# Issue #1556: SubGHz Read and Read Raw to retain configs after exit
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1556](https://github.com/flipperdevices/flipperzero-firmware/issues/1556)
+**Author:** @ppseprus
+**Created:** 2022-08-08T12:28:16Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+For _Read_ and _Read Raw_, usability would greatly improve if configurations of the previous "session" were to be loaded upon opening.
+
+Configurations to be persisted and loaded:
+* _Read_
+  * Frequency,
+  * Modulation and
+  * Hopping
+* _Read Raw_
+  * Frequency and
+  * Modulation
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01565-u2f-via-nfc.md
+++ b/.ai/upstream-issues/01565-u2f-via-nfc.md
@@ -1,0 +1,19 @@
+# Issue #1565: U2F via NFC
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1565](https://github.com/flipperdevices/flipperzero-firmware/issues/1565)
+**Author:** @nicoSWD
+**Created:** 2022-08-09T12:10:54Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### U2F via NFC
+
+If it's technically possible, it would be nice if we could use U2F via NFC, like say a YubiKey does. So it could be used with an iPhone, for example.
+
+This would be an extension to the existing U2F functionality.
+
+Any thoughts on this?
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01630-flipper-auto-shutdown-after-inactivity.md
+++ b/.ai/upstream-issues/01630-flipper-auto-shutdown-after-inactivity.md
@@ -1,0 +1,18 @@
+# Issue #1630: Flipper Auto Shutdown after inactivity
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1630](https://github.com/flipperdevices/flipperzero-firmware/issues/1630)
+**Author:** @ase1590
+**Created:** 2022-08-20T14:23:34Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+An inactivity auto-shutdown feature would be nice to have to prevent the battery from running down after being left on for days. 
+
+Having a customizable auto-shutdown inactivity timer available in the Flipper settings menu would be ideal in order to help prevent the battery from totally discharging while flipper is stored out of sight in a drawer :)
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01656-add-badusb-configs.md
+++ b/.ai/upstream-issues/01656-add-badusb-configs.md
@@ -1,0 +1,19 @@
+# Issue #1656: Add badusb configs
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1656](https://github.com/flipperdevices/flipperzero-firmware/issues/1656)
+**Author:** @FalsePhilosopher
+**Created:** 2022-08-24T18:38:45Z
+**Labels:** Feature Request, Backlog, USB
+
+## Description
+
+### Description of the feature you're suggesting.
+
+With the badusb keyboard layouts PR there's a config menu with selectable keyboard layout configs. It would be nice to do the same thing but with vid,pid,manf,serial configs so you don't have to do it on a script by script hard edit basis and could do it on the fly. It would also be nice if you could have in your badusb assets folder a copy of the linux foundations 20k vid/pid database random vid/pid selector and randomly generate a manf/serial mode as well.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01688-legic-prime-support.md
+++ b/.ai/upstream-issues/01688-legic-prime-support.md
@@ -1,0 +1,23 @@
+# Issue #1688: Legic Prime support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1688](https://github.com/flipperdevices/flipperzero-firmware/issues/1688)
+**Author:** @Builderhummel
+**Created:** 2022-08-31T08:57:36Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Legic Prime is a standard similar to Mifare and it is common in europe.
+
+It would be helpful to be able to read and emulate the legic prime cards just like mifare.
+
+(The algorithm is also available in the Proxmark3 source code, like the Mifare one)
+
+### Anything else?
+
+The flipper project is really interesting. Legic Prime support would make it a lot more practical.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01715-iso-14443-type-a-communication-sniffing.md
+++ b/.ai/upstream-issues/01715-iso-14443-type-a-communication-sniffing.md
@@ -1,0 +1,41 @@
+# Issue #1715: ISO 14443 Type A communication sniffing
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1715](https://github.com/flipperdevices/flipperzero-firmware/issues/1715)
+**Author:** @koalazak
+**Created:** 2022-09-07T14:56:17Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+It would be great a new option to sniff the communication between reader and external tags to then show anti-col and authentication encrypted but relevant values: `uid, tag challenge, reader challenge, reader response, tag response`
+
+Similar to `hf 14a snoop` + `hf list 14a` proxmark's commands.
+
+I imagine this in two steps:
+
+1. Actual sniff and save the data. 
+    NFC > Extra Actions > Eavesdrop
+    Message "Place Flipper and tag over the Reader..." and "REC" button on screen to start recording.
+    Stop button appears and once clicked "save>" button appears. 
+    Same behavior as "Read Raw" in sub-ghz menu. 
+
+2. Select the dump and click on "Auth Info" to show the hex values for `uid, tag challenge, reader challenge, reader response and tag response` for all authentication flows in the dump.
+     NFC > Saved > Dump1 > Auth Info
+     Show the 5 relevant values on screen
+
+![snoop_eng](https://user-images.githubusercontent.com/8185092/188903182-d7dd9026-5a27-43bf-8254-de31a3819ea7.jpeg)
+
+With this values you can crack the keys externally without brute force them. What do you think?
+
+### Anything else?
+
+Is this currently available on FZ but inside another feature I missed? (I mean the sniff part)
+Is the current FZ tag brutefoce attack based on dictionary or full scan?
+Please let me know.
+
+Thank you for your awesome work
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01800-remote-macros.md
+++ b/.ai/upstream-issues/01800-remote-macros.md
@@ -1,0 +1,32 @@
+# Issue #1800: Remote Macros
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1800](https://github.com/flipperdevices/flipperzero-firmware/issues/1800)
+**Author:** @uintdev
+**Created:** 2022-09-28T17:20:53Z
+**Labels:** Feature Request, Backlog, Infrared
+
+## Description
+
+### Description of the feature you're suggesting.
+
+The IR remote application is a great bit of functionally that makes it possible to control multiple devices from a single Flipper.
+As useful as it is, situations when using the physical navigation keys to change the button selection and then performing button combinations manually can make it time consuming to use. For example, changing TV channel to one that has multiple numbers in the channel number or trying to navigate an interface with exact key combinations (i.e. menus). If they’re common key presses, why not reduce the friction?
+
+My idea is remote macros. The process I have in mind is as follows:
+- User creates a remote/button as usual
+- While in the `learn new remote` section, offer the option to create a macro (menu or present option on the bottom corner)
+- Listen to all captured data as it comes through, adding delays in between (relative to how long a user waits between key presses — taking out any from before the first and after the last key press in the recording session)
+- Press a key on the Flipper to lock in the capture and save the macro (if a preview is included, perhaps the amount of key presses could be shown at least)
+- Macro gets assigned to a button for the remote
+- When pressing a macro button, show the same sort of cancellable progress dialog as the universal remote as to show progress of the macro runtime
+
+Ideally, users should be able to manually edit the remote file as usual but be able to adjust delays if needs be (i.e. loading times on the device being controlled may not be consistent).
+
+As implied by the process steps I had detailed, the idea would be that this would use existing functionality as to make things more convenient for the end user and potentially development work.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01847-ibutton-ds1990a-emulation-doesnt-work.md
+++ b/.ai/upstream-issues/01847-ibutton-ds1990a-emulation-doesnt-work.md
@@ -1,0 +1,51 @@
+# Issue #1847: iButton ds1990a emulation doesn't work
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1847](https://github.com/flipperdevices/flipperzero-firmware/issues/1847)
+**Author:** @jagotu
+**Created:** 2022-10-07T22:09:00Z
+**Labels:** Bug, iButton
+
+## Description
+
+### Describe the bug.
+
+I've been having issues with emulating my iButton to the door lock, so I took a logic analyzer to it and got some recordings.
+
+It seems to me (and I'm an amateur at this) like the window between resets left by the reader is just 230 microseconds and the flipper doesn't react fast enough.
+
+This is what the emulation attempt looks like:
+![image](https://user-images.githubusercontent.com/2465633/194669046-1a928074-f868-40fa-ae8a-d9d99fb1405e.png)
+
+Between resets, there's just 230 microseconds:
+![image](https://user-images.githubusercontent.com/2465633/194669522-68e5d39f-4416-4e19-b6bc-7ea326cfaac1.png)
+
+I also MITM'd the actual key and it reacts with the presence signal in 35 microseconds:
+![image](https://user-images.githubusercontent.com/2465633/194669109-893ae21f-3115-4b65-acb8-6362fb8ca3cf.png)
+
+I also attach saleae recordings of the failed emulation attempt and what a succesful communication looks like. The MITM communaction is cut-off before the UID transmission but the beginning of the transaction is clearly visible.
+
+[1wire_saleae.zip](https://github.com/flipperdevices/flipperzero-firmware/files/9737690/1wire_saleae.zip)
+
+I have pretty much unlimited access to the button, the readers and the logic analyzer, so I can provide more captures if necessary.
+
+
+### Reproduction
+
+1. Emulate a ds1990a iButton
+2. Attach Flipper to the reader, making sure there is good connectivity.
+3. No reaction whatsoever from the reader.
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01886-nfc-st25ta-support.md
+++ b/.ai/upstream-issues/01886-nfc-st25ta-support.md
@@ -1,0 +1,26 @@
+# Issue #1886: NFC st25ta support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1886](https://github.com/flipperdevices/flipperzero-firmware/issues/1886)
+**Author:** @SkalkaA
+**Created:** 2022-10-17T19:52:06Z
+**Labels:** Feature Request, Backlog, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Bought a smart lock ROTHULT made by IKEA, which uses st25ta 14443A cards for access. 
+Currently it is not possible to emulate these cards with a Flipper.  
+
+It is possible to read/emulate them, and to extract the password using a Proxmark3 in standalone mode by touching the lock itself, thereby making a copy of the master card*. It would be great if something similar could be done on the Flipper.
+
+
+
+*This shows the cloning mentioned: [https://www.youtube.com/watch?v=Q08qhJ3TOM8&ab_channel=QuentynTaylor](url)
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/01934-hopper-frequency-presets.md
+++ b/.ai/upstream-issues/01934-hopper-frequency-presets.md
@@ -1,0 +1,35 @@
+# Issue #1934: Hopper frequency presets
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/1934](https://github.com/flipperdevices/flipperzero-firmware/issues/1934)
+**Author:** @LowSkillDeveloper
+**Created:** 2022-10-26T21:30:34Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+It would be great if you could make different Hopper_frequency presets.
+And instead of the ON and OFF switch, you choose a preset.
+
+
+
+### Anything else?
+
+You can even limit their number and leave them in the setting_user file.
+
+Maybe something like this:
+Hopper_frequency_preset1, Hopper_frequency_preset2, Hopper_frequency_preset3
+
+```
+Hopper_frequency_preset1: 300000000
+Hopper_frequency_preset1: 330000000
+Hopper_frequency_preset1: 360000000
+
+Hopper_frequency_preset2: 400000000
+Hopper_frequency_preset2: 430000000
+Hopper_frequency_preset2: 460000000
+```
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02031-dont-attach-the-device-name-in-all-ble-advertisin.md
+++ b/.ai/upstream-issues/02031-dont-attach-the-device-name-in-all-ble-advertisin.md
@@ -1,0 +1,25 @@
+# Issue #2031: Don't attach the device name in all BLE advertising packages
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2031](https://github.com/flipperdevices/flipperzero-firmware/issues/2031)
+**Author:** @Semper-Viventem
+**Created:** 2022-11-20T01:10:38Z
+**Labels:** Feature Request, Bluetooth
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Currently, the BLE in the flipper is constantly broadcasting the static address and device name (including the unique flipper's name) to the BLE ether in all advertising packages. This is not a vulnerability but makes a risk of snooping on device owners. For example, any BLE-sniffer botnet in a city can track the movement of devices and compromise the owner's home address.
+
+There are two things that will help reduce the risk:
+* Add device name only in the pairing mode.
+* Use a `Random Private Resolvable Address` for BLE packages.
+
+For example, all apple devices change BLE addresses every 15 minutes to avoid the risks of surveillance.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02053-allow-loader-open-to-start-streaming-logs.md
+++ b/.ai/upstream-issues/02053-allow-loader-open-to-start-streaming-logs.md
@@ -1,0 +1,41 @@
+# Issue #2053: Allow loader open to start streaming logs
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2053](https://github.com/flipperdevices/flipperzero-firmware/issues/2053)
+**Author:** @NZSmartie
+**Created:** 2022-11-26T00:02:32Z
+**Labels:** Feature Request, Build System & Scripts
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+As a Flipper Application Developer, I would like to see application logs when deploying and running the fap through FBT.
+
+What I would expect to see when running `./fbt launch_app APPSRC=applications_user\my_app`
+```
+        SDKCHK  firmware\targets\f7\api_symbols.csv
+API version 7.5 is up to date
+python "./scripts/runfap.py" "build\f7-firmware-D\.extapps\my_app.fap" --fap_dst_dir "/ext/apps/"
+        APPCHK  build\f7-firmware-D\.extapps\my_app.fap
+2022-11-26 12:14:16,644 [INFO] Using FLIP_GLEXVD on COM10
+2022-11-26 12:14:16,694 [INFO] Installing "build\f7-firmware-D\.extapps\my_app.fap" to /ext/apps/my_app.fap
+2454608 [I][fap_loader_app] FAP Loader is loading /any/apps/my_app.fap
+2454613 [I][AnimationManager] Unload animation 'L1_Waves_128x50'
+2454632 [I][fap_loader_app] FAP Loader is mapping
+2454637 [I][elf] Total size of loaded sections: 118
+2454639 [I][fap_loader_app] Loaded in 31ms
+2454642 [I][fap_loader_app] FAP Loader is starting app
+2454645 [I][my_app] Hello, may I have some phish?
+2454648 [I][my_app] Please and Thank you~
+2454656 [I][fap_loader_app] FAP app returned: 0
+2454673 [I][LoaderSrv] Application stopped. Free heap: 135080
+```
+
+Instead, I only see the log output from `runfap.py` and none of the logs from the Flipper itself without needing to open a separate terminal and invoking `logs`
+
+### Anything else?
+
+It may be beneficial to allow specifying a log filter for known application tags to reduce the noise from other parts of the system
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02079-ed25519-support-for-u2f.md
+++ b/.ai/upstream-issues/02079-ed25519-support-for-u2f.md
@@ -1,0 +1,57 @@
+# Issue #2079: ED25519 support for U2F
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2079](https://github.com/flipperdevices/flipperzero-firmware/issues/2079)
+**Author:** @exussum12
+**Created:** 2022-12-02T13:07:50Z
+**Labels:** Feature Request, USB
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Using the flipper zero as my private key for ssh I would expect 
+
+`ssh-keygen -t ed25519-sk -f ~/.ssh/flipper.pub`
+
+
+to generate a key in the same way 
+
+
+`ssh-keygen -t ecdsa-sk -f ~/.ssh/flipper.pub`
+
+
+does. (the ecdsa works as expected and I can ssh using this as the key) 
+
+
+Output is currently 
+```
+Generating public/private ed25519-sk key pair.
+You may need to touch your authenticator to authorize key generation.
+Key enrollment failed: invalid format
+````
+
+the -vvv logs too
+
+```
+debug1: sshsk_enroll: using random challenge
+debug1: sk_probe: 1 device(s) detected
+debug1: sk_probe: selecting sk by touch
+debug1: ssh_sk_enroll: using device /dev/hidraw9
+debug1: ssh_sk_enroll: fido_dev_make_cred: FIDO_ERR_INVALID_ARGUMENT
+debug1: sshsk_enroll: provider "internal" failure -1
+debug1: ssh-sk-helper: Enrollment failed: invalid format
+debug1: main: reply len 8
+debug3: ssh_msg_send: type 5
+debug1: client_converse: helper returned error -4
+debug3: reap_helper: pid=72051
+Key enrollment failed: invalid format
+
+```
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02104-change-usb-vendor-id-and-product-id-to-something-n.md
+++ b/.ai/upstream-issues/02104-change-usb-vendor-id-and-product-id-to-something-n.md
@@ -1,0 +1,26 @@
+# Issue #2104: Change USB Vendor ID and Product ID to something non generic
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2104](https://github.com/flipperdevices/flipperzero-firmware/issues/2104)
+**Author:** @ikilledmypc
+**Created:** 2022-12-08T08:55:50Z
+**Labels:** Feature Request, Backlog, USB
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Currently the flipper device when connected to USB reports itself as a component id for the STM microcontroller and a generic USB device as product ID. Since snaps use this information to allow usage inside of snaps like Firefox. It's currently impossible to use the flipper for U2F on operating systems which use snaps like Ubuntu. 
+
+It would be great if flippedevices would apply for their own vendor id / product id. So this issue can be resolved.
+
+https://www.usb.org/getting-vendor-id
+
+Related issue:
+[Pull Request](https://github.com/snapcore/snapd/pull/12003)
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02231-apple-magsafe-emulation.md
+++ b/.ai/upstream-issues/02231-apple-magsafe-emulation.md
@@ -1,0 +1,19 @@
+# Issue #2231: Apple magsafe emulation
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2231](https://github.com/flipperdevices/flipperzero-firmware/issues/2231)
+**Author:** @bettse
+**Created:** 2022-12-31T04:02:38Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Very low priority, but I was thinking it would be fun to have an NFC menu item for emulation an Apple magsafe device like a phone case or wallet.  Or maybe also a format so one could scan existing, save, emulate, etc.  Lots of options, very minor benefit.  The magsafe devices appear as a type 4 tag with an NDEF record, the CC file contains bytes that indicate the specific color, device type (wallet/case), etc.  They use an unusual anti-collision, in theory to prevent overlap with regular 14a NFC.  Proxmark has lots of the anti-col details (https://github.com/RfidResearchGroup/proxmark3/blob/97e394c58a649d5f74d101202a76214e5e70d596/include/protocols.h#L163), and iceman rfid discord has some example CC in the back history.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02385-mizip-keys-and-card-read-support.md
+++ b/.ai/upstream-issues/02385-mizip-keys-and-card-read-support.md
@@ -1,0 +1,42 @@
+# Issue #2385: MiZiP keys and card read support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2385](https://github.com/flipperdevices/flipperzero-firmware/issues/2385)
+**Author:** @LowSkillDeveloper
+**Created:** 2023-02-11T20:22:32Z
+**Labels:** Feature Request, NFC, RFID 125kHz
+
+## Description
+
+I have a "MiZiP" key for the coffee machine. As I understand it, they come in 2 types, NFC and RFID. And maybe they contain information about the balance on the key. But the flipper can't read the balance from these keys.
+Or maybe they use a database on their side, . But even so, flipper cannot read the card id.
+
+![MIZIP](https://user-images.githubusercontent.com/25121341/218278516-43397a4d-f52e-40a8-96e9-dcd3805be96d.jpg)
+
+
+My flipper and phone does not see the NFC, so I can assume that the key is RFID.
+When reading RFID with Flipper Zero, it gives this:
+
+![Screenshot-20230211-205306](https://user-images.githubusercontent.com/25121341/218278492-de5cb420-1a22-490c-9544-1809774602e8.png)
+
+> Filetype: Flipper RFID key
+> Version: 1
+> Key type: EM4100
+> Data: 00 00 00 00 00
+
+
+I also did "Read RAW RFID data" when the balance on the key was different. 88 coins, 82, 78, 66.
+I don't know how and which program use to read RAW files, so I'll just attach them here:
+https://github.com/LowSkillDeveloper/mizip-flipper-temp
+
+
+Having a dump of the same key with different balances, I think it is possible to find a changing value if it is in the key. Or at least Flipper will be able to read the id of the key.
+
+Also this is official site with information about MiZiP: https://newis.evocagroup.com/en/payment-solutions/mizip
+Perhaps they also use specific NFC, so the flipper can't detect it?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02386-indala-224-card-not-being-read.md
+++ b/.ai/upstream-issues/02386-indala-224-card-not-being-read.md
@@ -1,0 +1,34 @@
+# Issue #2386: Indala 224 card not being read
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2386](https://github.com/flipperdevices/flipperzero-firmware/issues/2386)
+**Author:** @Divide-By-0
+**Created:** 2023-02-12T00:43:05Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the bug.
+
+I have a dual Indala 125 kHz ID and Mifare Classic 13.56 mHz card, and the Mifare classic reads fine on NFC. The Indala should read on the Extra Actions menu but nothing is detected.
+
+### Reproduction
+
+Switch to Indala mode
+Try to read
+It doesn't read
+
+### Target
+
+Indala card, len 224. Proxmark 3 recognizes it as chipset detection: EM4x05 / EM4x69.
+The proxmark sometimes confueses it for a `COTAG Found: FC 240, CN: 64702 Raw: EBE3...`
+
+### Logs
+
+There's nothing shown on the screen, what command is most useful for me to put logs?
+
+### Anything else?
+
+I can read it on the Proxmark 3 (but not write it), it starts with 80000003...
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02465-detect-sl-sweden-transport-card-nfc.md
+++ b/.ai/upstream-issues/02465-detect-sl-sweden-transport-card-nfc.md
@@ -1,0 +1,46 @@
+# Issue #2465: Detect SL (sweden transport card) NFC
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2465](https://github.com/flipperdevices/flipperzero-firmware/issues/2465)
+**Author:** @xSean145
+**Created:** 2023-03-05T22:07:15Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Flipper Zero does not detect or read this card. Add support to detect and read this card.
+Proxmark pulled this info from the card. (UID censored)
+
+[usb] pm3 --> hf search
+ 🕕  Searching for ISO14443-A tag...          
+[+]  UID: XX XX XX XX XX XX XX 
+[+] ATQA: 00 44
+[+]  SAK: 60 [1]
+[+] MANUFACTURER: Infineon Technologies AG Germany
+[=] -------------------------- ATS --------------------------
+[+] ATS: 0B 78 80 74 03 80 54 05 30 3E 0F [ CF 00 ]
+[=]      0B...............  TL    length is 11 bytes
+[=]         78............  T0    TA1 is present, TB1 is present, TC1 is present, FSCI is 8 (FSC = 256)
+[=]            80.........  TA1   different divisors are NOT supported, DR: [], DS: []
+[=]               74......  TB1   SFGI = 4 (SFGT = 65536/fc), FWI = 7 (FWT = 524288/fc)
+[=]                  03...  TC1   NAD is supported, CID is supported
+
+[=] -------------------- Historical bytes --------------------
+[+]   805405303E0F  (compact TLV data object)
+[=]     54  05303E0F   Card issuer data
+
+[?] Hint: try `hf mfu info`
+
+
+[+] Valid ISO 14443-A tag found
+
+[=] Short AID search:
+[?] Hint: try emv commands
+
+### Anything else?
+
+It is recognized as a iso14443-4a.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02513-u2f-over-bluetooth.md
+++ b/.ai/upstream-issues/02513-u2f-over-bluetooth.md
@@ -1,0 +1,19 @@
+# Issue #2513: U2F over Bluetooth
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2513](https://github.com/flipperdevices/flipperzero-firmware/issues/2513)
+**Author:** @Kami-no
+**Created:** 2023-03-19T10:25:49Z
+**Labels:** Feature Request, Backlog, Bluetooth
+
+## Description
+
+### Description of the feature you're suggesting.
+
+It would be great to have BT support because wires are boring and MacBook has no NFC.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02562-skylanders-real-time-write-issue.md
+++ b/.ai/upstream-issues/02562-skylanders-real-time-write-issue.md
@@ -1,0 +1,21 @@
+# Issue #2562: Skylanders real-time write issue
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2562](https://github.com/flipperdevices/flipperzero-firmware/issues/2562)
+**Author:** @Mikeonut
+**Created:** 2023-04-04T04:35:11Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+While Skylanders can work after being converted from .bin to .nfc files, they can only currently function on the Switch in a proper manner. In events which the portal would write to the tag, it will fail, unload the character, and re-set the figure to its original state. No progress can be made on the figure files. The portal writes to the figure when applying xp, gold, hats, upgrades, nicknames, basically everything you can do with an actual figure.
+
+There needs to be a way to allow for these changes to be applied in real time so that issues like this in game do not occur, otherwise the only game that this device will work on is the Nintendo switch version of Imaginators. This issue also probably affects Disney Infinity figures as well.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02563-u2f-does-not-work-with-some-services.md
+++ b/.ai/upstream-issues/02563-u2f-does-not-work-with-some-services.md
@@ -1,0 +1,31 @@
+# Issue #2563: U2F does not work with some services
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2563](https://github.com/flipperdevices/flipperzero-firmware/issues/2563)
+**Author:** @JulyIghor
+**Created:** 2023-04-05T01:45:29Z
+**Labels:** USB, Bug
+
+## Description
+
+### Describe the bug.
+
+Flipper Zero's U2F does not work with Facebook via a web browser
+
+### Reproduction
+
+1. Open Safari, macOS
+2. Visit facebook.com
+3. Try to add Flipper Zero's U2F as a security key
+4. You get infinite load instead of the key to be added
+
+### Target
+
+U2F do work with Facebook
+
+### Anything else?
+
+YubiKey works as expected with Facebook, but Flipper Zero can't be added in any case.
+Flipper Zero U2F working fine with GMail
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02578-new-rfid-card-protocol-support-proxlite-entree-pr.md
+++ b/.ai/upstream-issues/02578-new-rfid-card-protocol-support-proxlite-entree-pr.md
@@ -1,0 +1,28 @@
+# Issue #2578: New RFID Card Protocol Support (ProxLite/Entree Prox)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2578](https://github.com/flipperdevices/flipperzero-firmware/issues/2578)
+**Author:** @zigad
+**Created:** 2023-04-12T06:51:19Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+I have a access card that is completely white and has no markers just few dots.
+
+![Image](https://user-images.githubusercontent.com/41201503/231374791-6e420592-8741-40fd-ae17-1d918e567240.jpeg)
+
+
+It can be read with this reader: [GE Security 430222003 Model T-100 reader, Black, mini-mullion, GE Proximity (ProxLite, Entree Prox), Wiegand only 13](https://www.surveillance-video.com/security-430222003.html) So I guess the protocol for this card is ProxLite or Entree Prox.
+
+FCC ID of the reader: [R2L1050MINI](https://fccid.io/R2L1050MINI)
+
+This is the RAW reading of the card: [RfidRecordRaw.zip](https://github.com/flipperdevices/flipperzero-firmware/files/11208071/RfidRecordRaw.zip)
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02596-set-minimum-battery-voltage.md
+++ b/.ai/upstream-issues/02596-set-minimum-battery-voltage.md
@@ -1,0 +1,13 @@
+# Issue #2596: Set minimum battery voltage
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2596](https://github.com/flipperdevices/flipperzero-firmware/issues/2596)
+**Author:** @LeasyBen
+**Created:** 2023-04-19T01:59:10Z
+**Labels:** Bug, Core+Services
+
+## Description
+
+I noticed that the flipper identifies 0% charge when the battery hits 2.8v, this seems a little low for regular lipo batteries. Is there a way we can set it to shut off at 3.5v instead?
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02609-fix-saving-selected-settings-in-sub-ghz.md
+++ b/.ai/upstream-issues/02609-fix-saving-selected-settings-in-sub-ghz.md
@@ -1,0 +1,49 @@
+# Issue #2609: Fix saving selected settings in Sub-GHz
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2609](https://github.com/flipperdevices/flipperzero-firmware/issues/2609)
+**Author:** @krolchonok
+**Created:** 2023-04-24T23:27:19Z
+**Labels:** Sub-GHz, Bug
+
+## Description
+
+### Describe the bug.
+
+When you select the settings in "Config" in Read - Sub-GHz and then exit or view the signal information, the "Modulation" setting switches to the standard one.
+
+### Reproduction
+
+EN (ya.translate):
+1. Log in to SubGhz - read
+2. Catch the signal (Any)
+3. After the capture, go to Config
+4. Change the modulation to another
+5. Go back
+6. Open the signal information
+7. Go back to the scan menu
+
+
+Rus:
+1. Зайти в SubGhz - read
+2. Поймать сигнал (Любой)
+3. После поимки зайти в Config
+4. Поменять модуляцию на другую
+5. Вернуться назад
+6. Открыть информацию о сигнале
+7. Вернутся обратно в меню сканирования
+
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02634-cant-read-my-egym-rfid-card.md
+++ b/.ai/upstream-issues/02634-cant-read-my-egym-rfid-card.md
@@ -1,0 +1,26 @@
+# Issue #2634: Can't read my EGYM RFID card
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2634](https://github.com/flipperdevices/flipperzero-firmware/issues/2634)
+**Author:** @Boringsapiens
+**Created:** 2023-05-04T14:01:02Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Hello,
+
+I tried to read my EGYM (Fitness club) RFID card in order to clone to the ring or bracelet but failed. 
+[Fit123.psk.raw.zip](https://github.com/flipperdevices/flipperzero-firmware/files/11398251/Fit123.psk.raw.zip)
+
+Could you please analyze it and add it, if possible, for the upcoming releases? These EGYM machines are getting popular and I guess people will be interested in such capabilities.
+
+Thanks!
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02642-shortcuts-to-change-frequency-in-sub-ghz-read-.md
+++ b/.ai/upstream-issues/02642-shortcuts-to-change-frequency-in-sub-ghz-read-.md
@@ -1,0 +1,19 @@
+# Issue #2642: Shortcuts to change frequency in Sub-GHz Read 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2642](https://github.com/flipperdevices/flipperzero-firmware/issues/2642)
+**Author:** @xologram
+**Created:** 2023-05-06T08:46:08Z
+**Labels:** Feature Request, Sub-GHz, UI
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Right now SubGHz Read places FZ in read mode with left key to go to config, leaving other buttons unused. Up/Down could be Freq+ and Freq- and right could cycle through modulation. I think it will make it more user friendly. Possible?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02729-making-your-own-infrared-playlist-.md
+++ b/.ai/upstream-issues/02729-making-your-own-infrared-playlist-.md
@@ -1,0 +1,13 @@
+# Issue #2729: Making your own Infrared playlist 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2729](https://github.com/flipperdevices/flipperzero-firmware/issues/2729)
+**Author:** @Re3koning
+**Created:** 2023-06-03T21:21:32Z
+**Labels:** Feature Request, Infrared
+
+## Description
+
+It would be a nice feature to be able to make your own playlist of infrared signals just like the bruteforcer that works as the universal remote.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02733-nexwatch-nexkey-support-added-in-.84-not-working--.md
+++ b/.ai/upstream-issues/02733-nexwatch-nexkey-support-added-in-.84-not-working--.md
@@ -1,0 +1,89 @@
+# Issue #2733: NexWatch/NexKey support added in .84 not working - will not read cards
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2733](https://github.com/flipperdevices/flipperzero-firmware/issues/2733)
+**Author:** @i-am-mandalore
+**Created:** 2023-06-05T13:48:32Z
+**Labels:** RFID 125kHz, Bug
+
+## Description
+
+### Describe the bug.
+
+Pull request 2680 (https://github.com/flipperdevices/flipperzero-firmware/pull/2680) was supposed to add support for NexWatch/NexKey, however with the new version installed I still cannot read cards.  I have tried both a NexWatch NexKey card, as well as a NexKey card from after Honeywell acquired them.  Neither works.  I can't seem to find the RFID read raw capability in the Flipper that I thought used to be there, but I'm adding scans of two keys from a Proxmark.  
+
+I have also performed a full format of the SD card and factory reset of the device prior to reinstalling the firmware/databases and trying again.  No change.
+
+NexWatch NexKey (physical card ID 86594567  6905):
+
+[usb] pm3 --> lf search
+
+[=] NOTE: some demods output possible binary
+[=] if it finds something that looks like a tag
+[=] False Positives ARE possible
+[=]
+[=] Checking for known tags...
+[=]
+[=] Inverted the demodulated data
+[+]  NexWatch raw id : 0x40c00080
+[+]     Magic number : 0x84
+[+]         88bit id : 86594567 (0x05295407)
+[+]             mode : 1
+[=]  Raw : 560000000002424B1D10EF00
+
+[+] Valid NexWatch ID found!
+
+[=] Couldn't identify a chipset
+[usb] pm3 --> data print
+[+] DemodBuffer:
+[+] 01010110000000000000000000000000
+[+] 00000000000000100100001001001011
+[+] 00011101000100001110111100000000
+[+] 00000000000000000000000000000000
+
+Honeywell NexKey (physical card ID 78782701  28009):
+
+[usb] pm3 --> lf search
+
+[=] NOTE: some demods output possible binary
+[=] if it finds something that looks like a tag
+[=] False Positives ARE possible
+[=]
+[=] Checking for known tags...
+[=]
+[=] Inverted the demodulated data
+[+]  NexWatch raw id : 0x40c00080
+[+]      fingerprint : Nexkey
+[+]         88bit id : 78782701 (0x04b220ed)
+[+]             mode : 1
+[=]  Raw : 5600000000517419411B0D00
+
+[+] Valid NexWatch ID found!
+
+[=] Couldn't identify a chipset
+[usb] pm3 --> data print
+[+] DemodBuffer:
+[+] 01010110000000000000000000000000
+[+] 00000000010100010111010000011001
+[+] 01000001000110110000110100000000
+[+] 00000000000000000000000000000000
+
+### Reproduction
+
+1. Open 125kHz RFID app
+2. Place Flipper over card
+3. Select "Read"
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02775-mifare-plus-golmar-key-is-not-emulated-properly.md
+++ b/.ai/upstream-issues/02775-mifare-plus-golmar-key-is-not-emulated-properly.md
@@ -1,0 +1,55 @@
+# Issue #2775: Mifare Plus golmar key is not emulated properly
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2775](https://github.com/flipperdevices/flipperzero-firmware/issues/2775)
+**Author:** @mgrybyk
+**Created:** 2023-06-13T23:23:45Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+Emulation of golmar 13.56MHz tag that supports anti-copy encryption AES-128 doesn't work correctly.
+
+
+### Reproduction
+
+1. Read [golmar](https://www.golmar-seguridad.es/productos/tagdoor-mf-plus#product) key
+2. Emulate it
+
+**Actual Result**
+the door won't open, the reader doesn't react anyhow.
+
+**Expected Result**
+the door should open
+
+**Additional Info**
+- my key [key.nfc.txt](https://github.com/flipperdevices/flipperzero-firmware/files/11729188/key.nfc.txt)
+- I have 6 different readers, tried to use detect reader feature for all of them but still can see only sector 0. See [mfkey32.log](https://github.com/flipperdevices/flipperzero-firmware/files/11740128/mfkey32.log).
+- the code written on the key is `80555B62663004`
+
+
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+Filetype: Flipper NFC keys
+Version: 1
+Mifare Classic type: 1K
+Key A map: 000000000000FFFF
+Key B map: 000000000000FFFF
+Key A sector 0: 88 29 DA 9D AF 76
+Key B sector 0: 88 29 DA 9D AF 76
+```
+
+
+### Anything else?
+
+cc @Astrrra
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02777-rfid-raw---keri-systems-pkt-10x-standard-light-pro.md
+++ b/.ai/upstream-issues/02777-rfid-raw---keri-systems-pkt-10x-standard-light-pro.md
@@ -1,0 +1,25 @@
+# Issue #2777: RFID Raw - Keri Systems PKT-10X Standard Light Proximity Key Tag
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2777](https://github.com/flipperdevices/flipperzero-firmware/issues/2777)
+**Author:** @JReming85
+**Created:** 2023-06-16T01:20:21Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Would love it if you could implement this RFID tag.
+
+They are the key tag our area uses to allow us to get into the mail and laundry room and pool.
+
+We only get 1, and if we lose it we have to pay $50 for a replacement.  Would rather just clone it and keep the original safe.
+[rfid backups.zip](https://github.com/flipperdevices/flipperzero-firmware/files/11764822/rfid.backups.zip)
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02796-flipper-unable-to-read-access-card.md
+++ b/.ai/upstream-issues/02796-flipper-unable-to-read-access-card.md
@@ -1,0 +1,33 @@
+# Issue #2796: Flipper unable to read access card
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2796](https://github.com/flipperdevices/flipperzero-firmware/issues/2796)
+**Author:** @DamianCPH
+**Created:** 2023-06-22T19:01:42Z
+**Labels:** Feature Request, NFC, RFID 125kHz
+
+## Description
+
+### Describe the bug.
+
+I have an access card for work that I have tried to read, its RFID and I have been only able to read the Raw data, I'm unsure how to view this or what to do with it and I've read I can report it as an issue that maybe one of you can help, it would be really appreciated if you could as I'd like to reproduce this as a key fob rather than card.
+[RfidRecord.ask.zip](https://github.com/flipperdevices/flipperzero-firmware/files/11839309/RfidRecord.ask.zip)
+
+
+### Reproduction
+
+N/A
+
+### Target
+
+RFID Access Card
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02805-nfc-flipper-emulation-stopped-working-on-bas-ip-.md
+++ b/.ai/upstream-issues/02805-nfc-flipper-emulation-stopped-working-on-bas-ip-.md
@@ -1,0 +1,57 @@
+# Issue #2805: [NFC] Flipper Emulation stopped working on BAS-IP BME-03 after enabling reader's security profile
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2805](https://github.com/flipperdevices/flipperzero-firmware/issues/2805)
+**Author:** @mishamyte
+**Created:** 2023-06-26T22:09:00Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the bug.
+
+There is an object with access system built on top of BAS-IP panels (BME-03 reader) + U-Prox readers (U-Prox SE mini + U-Prox SL mini). Mifare 1K tags were used. Initially the whole system worked only with tag UID. For that moment emulation of tag worked fine at all present readers.
+
+Then the decision were taken to increase the security level. For that purposes new MFP tags were bought and all reader's settings were updated: added MFP profile and (what is important) MFC profile was added (for backward compatibility of all issued tags). 
+
+The one key is used for all issued MFC tags, all sectors are protected by it (both A + B keys).  Reader tries to authenticate with that key for all sectors sequentially until auth will be successful.  Filter only against MF Zero is present.
+
+After applying of those changes Flipper's emulation stopped working on the panels with BME-03 reader (and it is working on all other readers). All other tags (like MF-3, multiple versions of chinese CUID, Gen 4 GTU card) are working fine.
+
+I made the dumps by Proxmark3, visually it looks like protocol executes fine. So I have a suggestion it could be a hardware error. 
+But before that I decided to create that bug report for checking is it not a software problem. 
+
+Thanks!
+
+### Reproduction
+
+1. Open saved tag (full decrypted with a know key, all sectors are read successfully)
+2. Emulate it
+3. Try to authenticate via panel with BAS-IP BME-03 reader
+
+_Expected result:_
+Door will be opened
+
+_Actual result:_
+Door is not opened
+
+### Target
+
+NFC
+
+### Logs
+
+Proxmark3 traces are attached:
+[proxmark3-traces.zip](https://github.com/flipperdevices/flipperzero-firmware/files/11875049/proxmark3-traces.zip)
+
+Original - original tag's trace
+Flipper - Flipper's trace
+
+### Anything else?
+
+**Firmware version:** 0.85.2
+_Dump file could be shared securely if needed_
+
+CC @Astrrra prob?
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02838-frequencies-allowed-for-costa-rica.md
+++ b/.ai/upstream-issues/02838-frequencies-allowed-for-costa-rica.md
@@ -1,0 +1,25 @@
+# Issue #2838: Frequencies allowed for Costa Rica
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2838](https://github.com/flipperdevices/flipperzero-firmware/issues/2838)
+**Author:** @ngonzalez456
+**Created:** 2023-07-04T03:18:29Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+As can be read here: [http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?nValor1=1&nValor2=53219](url), Art. 7, there are no reserved frequencies in the space of 433AM which most of the controllers work around the country. This frequency is not even reserved for AM broadcast. 
+
+Another thing here: [http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?param1=NRTC&nValor1=1&nValor2=65675&nValor3=94853&strTipM=TC](url), Addendum VII, and here [http://www.pgrweb.go.cr/scij/Busqueda/Normativa/Normas/nrm_texto_completo.aspx?nValor1=1&nValor2=53219](url), Art. 37, there is no need to validate the device or ask for bandwidth when using less than 200mW (no external antena) or 2W (external antena), less than 200 meters radius and less than 24dBm transmitting power since they will be 'sporadic' transmissions.
+
+I know legal stuff and regulations is a whole thing and I might not be correct, but this is my shot to use any remote in Costa Rica and start learning as I did some time ago in my university.
+
+Thanks.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02859-nfc--copy-tag-content-to-empty-tags-instead-of-ini.md
+++ b/.ai/upstream-issues/02859-nfc--copy-tag-content-to-empty-tags-instead-of-ini.md
@@ -1,0 +1,19 @@
+# Issue #2859: NFC: Copy tag content to empty tags instead of initial card
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2859](https://github.com/flipperdevices/flipperzero-firmware/issues/2859)
+**Author:** @akaash00
+**Created:** 2023-07-10T19:13:05Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Is it possible to write a saved nfc tag to a new empty tag. This way I can make several tags with the same data content. Now you can only write to the initial card. Some systems don’t look at the uid, but look at the data content.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02864-nfc--cp-z-2-mod.-mf-i-cant-do-anti-collision-wi.md
+++ b/.ai/upstream-issues/02864-nfc--cp-z-2-mod.-mf-i-cant-do-anti-collision-wi.md
@@ -1,0 +1,111 @@
+# Issue #2864: NFC: CP-Z-2 (mod. MF-I) can't do anti-collision with Flipper Zero emulation
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2864](https://github.com/flipperdevices/flipperzero-firmware/issues/2864)
+**Author:** @AloneLiberty
+**Created:** 2023-07-11T21:59:24Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+To the ongoing problems with this reader (four-line version). I honestly don't know whose problem this is: reader works fine with fob and pm3 emulation, very bad with regular cards (pm3 sniffing making it even worse) and not working with Flipper Zero at all. Reader is UID only mode, no filters, reading gen1 fine.
+From Flipper Zero emulation trace I see it doesn't go any further after REQ (flipper_emulation.trace):
+
+```
+  213669024 |  213670080 | Rdr |26(7)                                                                    |     | REQA
+  213670080 |  213671268 |     |fdt (Frame Delay Time): 1188
+  213671268 |  213673636 | Tag |44  00                                                                   |     | 
+  215348512 |  215349568 | Rdr |26(7)                                                                    |     | REQA
+  215349568 |  215350756 |     |fdt (Frame Delay Time): 1188
+  215350756 |  215353124 | Tag |44  00                                                                   |     | 
+  217030020 |  217032388 | Tag |44  00                                                                   |     | 
+  218706992 |  218708048 | Rdr |26(7)                                                                    |     | REQA
+  218708048 |  218709236 |     |fdt (Frame Delay Time): 1188
+  218709236 |  218711604 | Tag |44  00                                                                   |     | 
+  220386416 |  220387472 | Rdr |26(7)                                                                    |     | REQA
+  220387472 |  220388660 |     |fdt (Frame Delay Time): 1188
+  220388660 |  220391028 | Tag |44  00                                                                   |     | 
+  222065824 |  222066880 | Rdr |26(7)                                                                    |     | REQA
+  222066880 |  222068068 |     |fdt (Frame Delay Time): 1188
+  222068068 |  222070436 | Tag |44  00                                                                   |     | 
+  223744976 |  223746032 | Rdr |26(7)                                                                    |     | REQA
+  223746032 |  223747220 |     |fdt (Frame Delay Time): 1188
+  223747220 |  223749588 | Tag |44  00                                                                   |     | 
+```
+
+As suggested in community, placing tag before Flipper affects it, reader selects tag UID, not Flipper. We can't move reader into secure mode (MFC reading) yet. But from this side, it is clear why Detect reader works in this case (tag UID == Flipper emulation UID)(flipper_fob_stack_emulation.trace):
+
+```
+  102553392 |  102554448 | Rdr |26(7)                                                                    |     | REQA
+  102554448 |  102555636 |     |fdt (Frame Delay Time): 1188
+  102555636 |  102556532 | Tag |04(6)                                                                    |     | 
+  102560160 |  102562624 | Rdr |93  20                                                                   |     | ANTICOLL
+  102562624 |  102563812 |     |fdt (Frame Delay Time): 1188
+  102563812 |  102564196 | Tag |00(2)                                                                    |     | 
+  102574800 |  102585328 | Rdr |93  70  00  56  78  bb  95  e8  1c                                       |  ok | SELECT_UID
+  106663872 |  106664928 | Rdr |26(7)                                                                    |     | REQA
+  106664928 |  106666116 |     |fdt (Frame Delay Time): 1188
+  106666116 |  106667268 | Tag |04                                                                       |     | 
+  106670640 |  106673104 | Rdr |93  20                                                                   |     | ANTICOLL
+  106673104 |  106674292 |     |fdt (Frame Delay Time): 1188
+  106674292 |  106674676 | Tag |00(2)                                                                    |     | 
+  106685280 |  106695808 | Rdr |93  70  00  56  78  bb  95  e8  1c                                       |  ok | SELECT_UID
+  108376880 |  108377936 | Rdr |26(7)                                                                    |     | REQA
+  108377936 |  108379108 |     |fdt (Frame Delay Time): 1172
+  108379108 |  108381476 | Tag |44  00                                                                   |     | 
+  108383648 |  108386112 | Rdr |93  20                                                                   |     | ANTICOLL
+  108386112 |  108387284 |     |fdt (Frame Delay Time): 1172
+  108387284 |  108392980 | Tag |04! d6! 35  f7! 97                                                       |     | 
+  108398288 |  108408816 | Rdr |93  70  00  56  78  bb  95  e8  1c                                       |  ok | SELECT_UID
+  110088896 |  110089952 | Rdr |26(7)                                                                    |     | REQA
+  110089952 |  110091140 |     |fdt (Frame Delay Time): 1188
+  110091140 |  110093508 | Tag |44  00                                                                   |     | 
+  110095664 |  110098128 | Rdr |93  20                                                                   |     | ANTICOLL
+  110098128 |  110099316 |     |fdt (Frame Delay Time): 1188
+  110099316 |  110105140 | Tag |04! d6! 3d! ff! 97!                                                      |     | 
+  110110304 |  110120832 | Rdr |93  70  00  56  78  bb  95  e8  1c                                       |  ok | SELECT_UID
+  111800976 |  111802032 | Rdr |26(7)                                                                    |     | REQA
+  111802032 |  111803220 |     |fdt (Frame Delay Time): 1188
+  111803220 |  111804116 | Tag |04(6)                                                                    |     | 
+  111807744 |  111810208 | Rdr |93  20                                                                   |     | ANTICOLL
+  111810208 |  111811396 |     |fdt (Frame Delay Time): 1188
+  111811396 |  111811780 | Tag |00(2)                                                                    |     | 
+  113492656 |  113493712 | Rdr |26(7)                                                                    |     | REQA
+```
+
+From our tests we seen Flipper Zero 2 times sending UID properly, but we couldn't replicate how we done it. NFC refactor branch doesn't change anything (tried UID emulation). Messing with st25r3916 registers also didn't change anything.
+
+Traces:
+[traces.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12021690/traces.zip)
+
+Regardless naming:
+`fob.trace` - regular gen1 fob, working great
+`card.trace` - regular gen1 card, working once in a while
+`flipper_emulation.trace` - Flipper Zero emulation, doesn't work
+`flipper_fob_stack.trace` - Flipper Zero emulation + fob at back
+`hf_sniff.pm3` - `hf sniff` on reader
+`hf_sniff_flipper.pm3` and `hf_sniff_flipper_two.pm3` - `hf sniff` on reader + Flipper Zero emulation
+`hf_sniff_fob.pm3` - `hf sniff` on reader + fob
+
+
+### Reproduction
+
+1. Emulate UID/MFC (doesn't matter) 
+2. Try to scan with CP-Z-2
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+@g3gg0 (_as emulation expert_) maybe you could suggest something? 
+Anti-collision preforms on ST25R3916 directly and _different frequency_ issue can't affect it?
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02866-1342khz-rfid-texas-instruments.md
+++ b/.ai/upstream-issues/02866-1342khz-rfid-texas-instruments.md
@@ -1,0 +1,23 @@
+# Issue #2866: 134,2khz RFID Texas instruments
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2866](https://github.com/flipperdevices/flipperzero-firmware/issues/2866)
+**Author:** @Marianovich
+**Created:** 2023-07-12T09:49:21Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+[ri-trp-dr2b.pdf](https://github.com/flipperdevices/flipperzero-firmware/files/12026388/ri-trp-dr2b.pdf)
+[RFID Raw Signal.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12026400/RFID.Raw.Signal.zip)
+
+Hi, I tried reading a RFID "Pill" used for production lots, but I was not able to do it. The attached specification sheet, mentions usage ISO 11784 and ISO 11785 compliance and the signal should be at 134,2khz. So it should be very similar to the animal RFID. Right now I´m not able to read it, even though the Flipper is blinking yellow...
+Maybe you can look into it? Thank you very much in advance!
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02877-u2f-security-key-not-supported-in-windows-11.md
+++ b/.ai/upstream-issues/02877-u2f-security-key-not-supported-in-windows-11.md
@@ -1,0 +1,23 @@
+# Issue #2877: U2F Security Key not supported in Windows 11
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2877](https://github.com/flipperdevices/flipperzero-firmware/issues/2877)
+**Author:** @SystemOfTheCSGO
+**Created:** 2023-07-14T08:53:26Z
+**Labels:** Feature Request, USB
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+The current module of security key U2F is not supported by windows.
+
+Reproduction
+
+Use the firmware as usual, get a clean install of windows 11, try to link the security key from flipper to windows, you will get a error: this device is not certified.
+
+### Anything else?
+
+This can be bypassed emulating headers of a certified key. (I’ve seen it done before, at least a homemade microsoft certified’ seckey.)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02898-buttons-for-onn-brand-roku-tvs-.md
+++ b/.ai/upstream-issues/02898-buttons-for-onn-brand-roku-tvs-.md
@@ -1,0 +1,46 @@
+# Issue #2898: Buttons for ONN brand ROKU TVs 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2898](https://github.com/flipperdevices/flipperzero-firmware/issues/2898)
+**Author:** @fennectech
+**Created:** 2023-07-19T04:50:57Z
+**Labels:** Feature Request, Infrared
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+I’d like to see these added to the universal remote library
+```
+Version: 1
+# 
+name: Vol -
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 10 EF 00 00
+# 
+name: Vol +
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 0F F0 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 20 DF 00 00
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 17 E8 00 00
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02925-stealth-mode.md
+++ b/.ai/upstream-issues/02925-stealth-mode.md
@@ -1,0 +1,19 @@
+# Issue #2925: Stealth mode
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2925](https://github.com/flipperdevices/flipperzero-firmware/issues/2925)
+**Author:** @Zarcolio
+**Created:** 2023-07-28T22:21:07Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Currently, it's easy for EDR to detect a Flipper Zero. It would be really nice if a stealth mode could be configured in which USB and Bluetooth connections can set to use custom VID & PID and MAC addresses. This way EDR detection could hopefully be bypassed. 
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02943-rfid-raw-reading-card-honeywell.md
+++ b/.ai/upstream-issues/02943-rfid-raw-reading-card-honeywell.md
@@ -1,0 +1,21 @@
+# Issue #2943: RFID RAW reading card (Honeywell)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2943](https://github.com/flipperdevices/flipperzero-firmware/issues/2943)
+**Author:** @M-Purple
+**Created:** 2023-08-03T13:33:17Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+I have RAW reading of my RFID card, there is a code on the card and brand name: Honeywell. How can I make this work on my Flipper Zero?
+[RAWreading_RFID.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12251326/RAWreading_RFID.zip)
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/02995-rfid-farpointe-pyramid-support.md
+++ b/.ai/upstream-issues/02995-rfid-farpointe-pyramid-support.md
@@ -1,0 +1,36 @@
+# Issue #2995: RFID Farpointe Pyramid support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/2995](https://github.com/flipperdevices/flipperzero-firmware/issues/2995)
+**Author:** @Tylerrattv
+**Created:** 2023-08-21T02:53:46Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the bug.
+
+Hi, 
+
+Got a unreadable tag. I believe this a "Farpointe Pyramid MAXSecure" format on a T5577 tag. 
+Have attached raw RFID files.
+[Unreadable.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12390646/Unreadable.zip)
+
+
+### Reproduction
+
+RFID Read
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03051-rfid-em4x50-protocol-support.md
+++ b/.ai/upstream-issues/03051-rfid-em4x50-protocol-support.md
@@ -1,0 +1,28 @@
+# Issue #3051: RFID EM4X50 protocol support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3051](https://github.com/flipperdevices/flipperzero-firmware/issues/3051)
+**Author:** @tcfsoft
+**Created:** 2023-09-07T15:32:23Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Can protocol EM4X50 be implemented? 
+Adding all info I have, also added proxmark dump in case it helps, in proxmark is recognized as EM4X50.
+
+Flipper raw files:
+[dump_ flipper.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12550847/dump_.flipper.zip)
+
+Proxmark dump:
+[dump_proxmark.zip](https://github.com/flipperdevices/flipperzero-firmware/files/12550857/dump_proxmark.zip)
+
+
+
+### Anything else?
+
+Let me know if I can help with anything else, thank you.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03159-nfc--show-card-sector-access-log-after-emulation-.md
+++ b/.ai/upstream-issues/03159-nfc--show-card-sector-access-log-after-emulation-.md
@@ -1,0 +1,21 @@
+# Issue #3159: NFC: Show card sector access log after emulation 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3159](https://github.com/flipperdevices/flipperzero-firmware/issues/3159)
+**Author:** @mh-
+**Created:** 2023-10-19T05:32:18Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+For analyzing a live RFID / NFC system it would be very helpful to know what the reader did during emulation. E.g. in Mifare systems usually the reader only tries to read a single card sector, using one of the two keys. 
+
+It would be tremendously helpful if Flipper could show a human-readable log of these actions after user ended the emulation of a card. 
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03182-add-new-subghz-protocol-for-clemsa-mastercode-mv12.md
+++ b/.ai/upstream-issues/03182-add-new-subghz-protocol-for-clemsa-mastercode-mv12.md
@@ -1,0 +1,43 @@
+# Issue #3182: Add new SubGhz protocol for Clemsa MasterCode MV12
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3182](https://github.com/flipperdevices/flipperzero-firmware/issues/3182)
+**Author:** @flipperzelebro
+**Created:** 2023-11-01T11:18:38Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I have a Clemsa Mastercode MV12 garage remote that its not supported now in flipper zero. 
+Its a fixed code 433.92 MHz remote with modulation AM270.
+
+Testing with flipperzero i have found that its very similar to Clemsa protocol already implemented, but with some changes:
+
+- Time of the On, Off, pause.
+- Length of the key.
+- Order of the bits for switches.  
+
+I attach the SUB files for te button 1 and button 2.
+The DIP configuration is :
+  
+(+): ---**---
+(o): --------
+(-): \*\*\*--\*\*\*
+
+I have already implemented the new protocol and could create a MR
+
+[Mv12_B1.zip](https://github.com/flipperdevices/flipperzero-firmware/files/13226175/Mv12_B1.zip)
+
+![617EPLOnN9L _AC_SL1024_](https://github.com/flipperdevices/flipperzero-firmware/assets/149575765/d9c464ca-e9dd-46fd-abee-26a1d5b00abb)
+
+![mando-de-garaje-clemsa-mastercode-mv-12](https://github.com/flipperdevices/flipperzero-firmware/assets/149575765/3c2dd3c0-cbcb-442b-9cb8-a96e343233d4)
+
+
+
+### Anything else?
+
+I have already implemented the new protocol and could create a MR
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03197-kdf-plugins.md
+++ b/.ai/upstream-issues/03197-kdf-plugins.md
@@ -1,0 +1,23 @@
+# Issue #3197: KDF plugins
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3197](https://github.com/flipperdevices/flipperzero-firmware/issues/3197)
+**Author:** @noproto
+**Created:** 2023-11-04T15:05:52Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+A significant enhancement for the NFC app would be an interface to allow libraries/shared objects to be registered (or loaded from a fixed SD card path) which could be used as custom dictionaries for bruteforce attacks. This is particularly useful for key derivation functions (KDFs).
+
+As discussed on the Q&A, we're hoping to identify an ideal location/API to implement this which would be compatible with multiple NFC protocols without duplicating code - such as MIFARE Classic, DESFire, and Ultralight C. Either C or JavaScript functions can be written for use with this handler. The external function is loaded from the SD card and called with the known card parameters (e.g. ATQA, SAK, CUID), which returns an array of zero or more keys. Each key is tested as a part of the overall dictionary attack against the card.
+
+This approach ensures that the firmware remains free from copyrighted or proprietary algorithms, while (often) eliminating more advanced NFC attacks such as MFKey or Nested.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03224-favorites-api.md
+++ b/.ai/upstream-issues/03224-favorites-api.md
@@ -1,0 +1,23 @@
+# Issue #3224: Favorites API
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3224](https://github.com/flipperdevices/flipperzero-firmware/issues/3224)
+**Author:** @jstefa
+**Created:** 2023-11-17T06:04:27Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Please create a favorites API for adding parts of particular apps-- for example, I would like a unified favorites screen with my most-used picopass cards (and would be great if I could shoot right into "emulate x card" instead of having to go through 5 button presses), IR remotes, and NFC cards.
+
+Ideally, if you could trigger a shortcut creation menu by long-pressing on a menu item in an app, then let me choose which shortcut screen to deposit that action on.  Even cooler still, let me schedule the action to a time or event-- like open X favorites menu when I am at a certain location on my phone.
+
+Anyway, thanks for considering.  Picopass dev on discord said he would consider implementing this if there was an API!
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03242-show-time-in-main-menu-instead-of-animations.md
+++ b/.ai/upstream-issues/03242-show-time-in-main-menu-instead-of-animations.md
@@ -1,0 +1,19 @@
+# Issue #3242: Show time in main menu instead of animations
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3242](https://github.com/flipperdevices/flipperzero-firmware/issues/3242)
+**Author:** @Danucosukosuko
+**Created:** 2023-11-24T22:17:25Z
+**Labels:** Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I would say that if you put an experimental option in the settings menu in the "Desktop" section to show the clock instead of the animations
+
+### Anything else?
+
+Nothing
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03276-cli-nfc-command-does-not-work-after-nfc-refactor.md
+++ b/.ai/upstream-issues/03276-cli-nfc-command-does-not-work-after-nfc-refactor.md
@@ -1,0 +1,64 @@
+# Issue #3276: cli nfc command does not work after NFC refactor
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3276](https://github.com/flipperdevices/flipperzero-firmware/issues/3276)
+**Author:** @u0d7i
+**Created:** 2023-12-07T12:19:31Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the bug.
+
+After NFC refactor, cli "nfc" command shows empty sub-command list and does not work anymore:
+```
++ device: /dev/ttyACM0
+starting cli, Ctrl+C to terminate
+
+              _.-------.._                    -,
+          .-"```"--..,,_/ /`-,               -,  \ 
+       .:"          /:/  /'\  \     ,_...,  `. |  |
+      /       ,----/:/  /`\ _\~`_-"`     _;
+     '      / /`"""'\ \ \.~`_-'      ,-"'/ 
+    |      | |  0    | | .-'      ,/`  /
+   |    ,..\ \     ,.-"`       ,/`    /
+  ;    :    `/`""\`           ,/--==,/-----,
+  |    `-...|        -.___-Z:_______J...---;
+  :         `                           _-'
+ _L_  _     ___  ___  ___  ___  ____--"`___  _     ___
+| __|| |   |_ _|| _ \| _ \| __|| _ \   / __|| |   |_ _|
+| _| | |__  | | |  _/|  _/| _| |   /  | (__ | |__  | |
+|_|  |____||___||_|  |_|  |___||_|_\   \___||____||___|
+
+Welcome to Flipper Zero Command Line Interface!
+Read Manual https://docs.flipperzero.one
+
+Firmware version: dev unknown (82baf1e9 built on 05-12-2023)
+
+>: nfc
+nfc
+Usage:
+nfc <cmd>
+Cmd list:
+
+>: 
+```
+
+### Reproduction
+
+1. Connect to FZ serial port
+2. Execute 'nfc' command via cli
+
+### Target
+
+7
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+tested on latest devbuild ATM (latest releases and rc's have the same issues)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03282-ntag216-unlocking-issue.md
+++ b/.ai/upstream-issues/03282-ntag216-unlocking-issue.md
@@ -1,0 +1,39 @@
+# Issue #3282: NTAG216 Unlocking Issue
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3282](https://github.com/flipperdevices/flipperzero-firmware/issues/3282)
+**Author:** @droidXrobot
+**Created:** 2023-12-10T22:53:53Z
+**Labels:** NFC
+
+## Description
+
+### Describe the bug.
+
+I tried to unlock an NTAG216 by inputting a password manually. I got a success messaging saying all pages were unlocked successfully but when I tried to read the tag again it said "Password-protected pages!"
+
+### Reproduction
+
+1.  Navigate to NFC
+2. Read a password protected NTAG216
+3.  More
+4. Unlock
+5. Enter password manually
+6. Save
+7. Continue
+8.  See message "All pages unlocked!"
+9. Exit and read card again. It says  "Password-protected pages!"
+
+### Target
+
+ 0.96.1
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+ Flipper firmware 0.96.1
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03296-inhibit-automatic-screen-locking-when-connected-vi.md
+++ b/.ai/upstream-issues/03296-inhibit-automatic-screen-locking-when-connected-vi.md
@@ -1,0 +1,21 @@
+# Issue #3296: Inhibit automatic screen locking when connected via USB CDC
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3296](https://github.com/flipperdevices/flipperzero-firmware/issues/3296)
+**Author:** @dogtopus
+**Created:** 2023-12-15T18:15:32Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Currently automatic screen lock will not be inhibited when Flipper is connected from e.g. qFlipper or PuTTY via USB CDC. This gets annoying when I need to manage files or use the console.
+
+Most scenes seem to inhibit screen lock already so it's probably not needed to introduce an entirely new feature.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03331-new-nfc-scanner-apis-dont-appear-to-work-when-use.md
+++ b/.ai/upstream-issues/03331-new-nfc-scanner-apis-dont-appear-to-work-when-use.md
@@ -1,0 +1,135 @@
+# Issue #3331: New NFC scanner APIs don't appear to work when used directly
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3331](https://github.com/flipperdevices/flipperzero-firmware/issues/3331)
+**Author:** @str4d
+**Created:** 2023-12-31T02:21:08Z
+**Labels:** NFC
+
+## Description
+
+### Describe the bug.
+
+I'm attempting to use the new `nfc_scanner_*` APIs in the Flipper Zero SDK.
+
+The thing I'm observing is that the `NfcScanner`'s internal logging shows it gets through the `NfcScannerStateIdle` handler, but never reaches `NfcScannerStateFindChildrenProtocols` (and therefore not `NfcScannerStateComplete` either, so it never calls my callback). But the ostensibly identical sequence of NFC API calls that the built-in `nfc` app uses, works perfectly.
+
+The main difference between my example app and the built-in `nfc` app is that my app's main thread sleeps after starting the scanner, while the built-in `nfc` app's main thread is running the event loop for the view dispatcher.
+
+### Reproduction
+
+1. Place the following files into `applications_user/nfc_scanner`:
+
+```python
+App(
+    appid="nfc_scanner",
+    name="NFC Scanner",
+    apptype=FlipperAppType.EXTERNAL,
+    targets=["f7"],
+    entry_point="nfc_scanner_app",
+    stack_size=5 * 1024,
+)
+```
+
+```cpp
+#include <furi.h>
+#include <furi_hal.h>
+
+#include <lib/nfc/nfc.h>
+#include <nfc/nfc_scanner.h>
+
+#define TAG "NfcScanner"
+
+void nfc_detect_scan_callback(NfcScannerEvent event, void* context) {
+    UNUSED(context);
+
+    FURI_LOG_I(TAG, "Scan callback called");
+    if(event.type == NfcScannerEventTypeDetected) {
+        FURI_LOG_I(TAG, "Detected %d protocols", event.data.protocol_num);
+    }
+}
+
+int32_t nfc_scanner_app(void* p) {
+    UNUSED(p);
+
+    Nfc* nfc = nfc_alloc();
+
+    FURI_LOG_I(TAG, "Scanning NFC cards for 5 seconds...");
+
+    NfcScanner* scanner = nfc_scanner_alloc(nfc);
+    nfc_scanner_start(scanner, nfc_detect_scan_callback, NULL);
+
+    furi_delay_us(5000000);
+
+    nfc_scanner_stop(scanner);
+    nfc_scanner_free(scanner);
+
+    FURI_LOG_I(TAG, "Finished scanning!");
+
+    nfc_free(nfc);
+
+    return 0;
+}
+```
+
+2. Compile and run the app on a Flipper Zero.
+
+### Target
+
+f7, firmware version 0.97.1.
+
+### Logs
+
+Running my example app above, I see the following debug logs:
+```text
+354500679 [I][Loader] Loading /ext/apps/nfc_scanner.fap
+354500712 [I][Elf] Total size of loaded sections: 299
+354500714 [I][Loader] Loaded in 35ms
+354500717 [I][NfcScanner] Scanning NFC cards for 5 seconds...
+354500721 [I][AnimationManager] Unload animation 'L1_Tv_128x47'
+354500726 [D][NfcScanner] Found 5 base protocols
+354506074 [I][NfcScanner] Finished scanning!
+354506088 [I][Loader] App returned: 0
+354506090 [I][Loader] Application stopped. Free heap: 141968
+```
+
+If I instead run the built-in `nfc` app and click "Read", with the same NFC card by the reader, I see:
+```text
+354700335 [D][NfcScanner] Found 5 base protocols
+354700399 [D][Nfc] FWT Timeout
+354700424 [D][Nfc] FWT Timeout
+354700476 [D][Nfc] FWT Timeout
+354700504 [D][Nfc] FWT Timeout
+354700519 [D][NfcScanner] Found 4 children
+354700576 [D][Nfc] FWT Timeout
+354700579 [D][Nfc] FWT Timeout
+354700612 [D][Nfc] FWT Timeout
+354700646 [D][Iso14443_4aPoller] Read ATS success
+354700688 [I][NfcScanner] Detected 1 protocols
+354700856 [I][Elf] Total size of loaded sections: 888
+354700858 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354700898 [I][Elf] Total size of loaded sections: 420
+354700900 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354700941 [I][Elf] Total size of loaded sections: 872
+354700944 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354700994 [I][Elf] Total size of loaded sections: 1244
+354700996 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701046 [I][Elf] Total size of loaded sections: 1324
+354701049 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701092 [I][Elf] Total size of loaded sections: 1724
+354701094 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701137 [I][Elf] Total size of loaded sections: 1768
+354701140 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701182 [I][Elf] Total size of loaded sections: 1464
+354701186 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701228 [I][Elf] Total size of loaded sections: 636
+354701232 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+354701235 [D][NfcSupportedCards] Loaded 9 plugins
+354701252 [D][Iso14443_4aPoller] Read ATS success
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03343-15693-listener-can-get-get-into-a-failed-in-some-n.md
+++ b/.ai/upstream-issues/03343-15693-listener-can-get-get-into-a-failed-in-some-n.md
@@ -1,0 +1,39 @@
+# Issue #3343: 15693 listener can get get into a failed in some noisy conditions and remain there until restart
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3343](https://github.com/flipperdevices/flipperzero-firmware/issues/3343)
+**Author:** @nvx
+**Created:** 2024-01-05T13:02:41Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+While tracking down some bugs I suspect were introduced with the NFC refactor I discovered an interesting condition that can occur in the 15693 emulation code.
+
+In `signal_reader_callback` in `iso15693_parser.c` when a SOF is recieved it then sets the expected demodulation mode to either 1or4 or 1or256 depending on what the SOF looked like. After this mode has been set remaining calls to the callback look for data encoded in that modulation only. The issue is that readers will generally only use one of the two modulations exclusively (for example picopass only supports the higher speed 1of4 mode) and there is no timeout that resets the state back to `Iso15693ParserStateParseSoF`, so under real world conditions sometimes a bit of noise can trigger the wrong mode at which point emulation will stop working until it is manually restarted as we never encounter the appropriate end of frame.
+
+I'd expect that the demodulator would upon encountering invalid modulation reset the state back to `Iso15693ParserStateParseSoF` so that it can start from the beginning again.
+
+### Reproduction
+
+1. Attach debugger
+2. Run picopass and emulate a credential
+3. Read the credential a bunch of times from varying distances (note at some point you may run into flipperdevices/flipperzero-good-faps#105 as well)
+4. When emulation stops working (everything looks fine on the FZ side of things, but the reader will not be able to see anything) add a breakpoint on the `signal_reader_callback` function
+5. Observe that `instance->state` is `Iso15693ParserStateParseFrame` and `instance->mode` is `Iso15693ParserMode1OutOf256` which isn't used by picopass and that in all subsequent calls to this function the state and mode remains unchanged
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03353-request-for-nld-bep-keyboard-layout-inclusion-ned.md
+++ b/.ai/upstream-issues/03353-request-for-nld-bep-keyboard-layout-inclusion-ned.md
@@ -1,0 +1,21 @@
+# Issue #3353: Request for NLD BEP keyboard Layout inclusion (Nederland form belgie)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3353](https://github.com/flipperdevices/flipperzero-firmware/issues/3353)
+**Author:** @Soka109
+**Created:** 2024-01-09T21:02:32Z
+**Labels:** Feature Request, USB
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Hello,
+
+I hope this message finds you well. Could you consider adding the NLD BEP (Nederlands België) keyboard layout? It would be greatly appreciated.
+
+### Anything else?
+
+Thank you,
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03416-amiibo-rewriting-to-nfc-apps-for-amiibo-not-workin.md
+++ b/.ai/upstream-issues/03416-amiibo-rewriting-to-nfc-apps-for-amiibo-not-workin.md
@@ -1,0 +1,31 @@
+# Issue #3416: Amiibo rewriting to nfc apps for amiibo not working  not reading as nfc 215 tag 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3416](https://github.com/flipperdevices/flipperzero-firmware/issues/3416)
+**Author:** @olg857
+**Created:** 2024-01-31T18:14:52Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+I’m trying to write the amiibo on an amiibo app going to nfc > add manually > NTAG215 > emulate not able to detect it’s an 215 tag on amiibo apps on iOS all amiibo apps not working 
+
+### Reproduction
+
+nfc > add manually > NTAG215 > emulate
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03426-canvas--fast-blit-functions.md
+++ b/.ai/upstream-issues/03426-canvas--fast-blit-functions.md
@@ -1,0 +1,167 @@
+# Issue #3426: Canvas: Fast blit function(s)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3426](https://github.com/flipperdevices/flipperzero-firmware/issues/3426)
+**Author:** @CookiePLMonster
+**Created:** 2024-02-05T17:57:14Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Since @skotopes mentioned in [another issue](https://github.com/flipperdevices/flipperzero-firmware/issues/3380#issuecomment-1905719195) that suggestions for Canvas API expansions can be considered, an addition to allow for fast blit of a buffer on-screen would be appreciated.
+
+Consider this demo example, based upon the Direct Draw API debug app. In this sample, I allocate a single 128x64px buffer, rasterize on it manually (in this case, a simple checkerboard, but in a real app it'd be substituted by more non-trivial workload, like in e.g. my Mode 7 demo), then I blit the buffer on screen in a single full-screen draw:
+
+<details>
+<summary>Sample app</summary>
+
+```cpp
+#include <furi.h>
+#include <gui/gui.h>
+#include <input/input.h>
+
+#define BUFFER_SIZE (32U)
+
+// This is simplified compared to the "traditional" bit band alias access, since we only occupy the bottom 256KB of SRAM anyway
+#define BIT_BAND_ALIAS(var) ((uint32_t*)(((uintptr_t)(var) << 5) | 0x22000000))
+
+[[maybe_unused]] static void canvas_blit_fast(Canvas* canvas, const uint8_t* bitmap) {
+    uint8_t* buf = canvas_get_buffer(canvas);
+
+    const uint32_t* bitmap_buffer = BIT_BAND_ALIAS(bitmap);
+    uint32_t* canvas_buffer = BIT_BAND_ALIAS(buf);
+    for(uint32_t y = 0; y < 64; ++y) {
+        const uint32_t tile_y = ((y & 0xFFFFFFF8) << 7) | (y & 7);
+        for(uint32_t x = 0; x < 128; ++x) {
+            const uint32_t column = tile_y + (x * 8);
+            canvas_buffer[column] = *bitmap_buffer++;
+        }
+    }
+}
+
+typedef struct {
+    FuriPubSub* input;
+    FuriPubSubSubscription* input_subscription;
+    Gui* gui;
+    Canvas* canvas;
+    bool stop;
+    uint8_t screen_buffer[16 * 64];
+} DirectDraw;
+
+static void gui_input_events_callback(const void* value, void* ctx) {
+    furi_assert(value);
+    furi_assert(ctx);
+
+    DirectDraw* instance = ctx;
+    const InputEvent* event = value;
+
+    if(event->key == InputKeyBack && event->type == InputTypeShort) {
+        instance->stop = true;
+    }
+}
+
+static DirectDraw* direct_draw_alloc() {
+    DirectDraw* instance = malloc(sizeof(DirectDraw));
+
+    instance->input = furi_record_open(RECORD_INPUT_EVENTS);
+    instance->gui = furi_record_open(RECORD_GUI);
+    instance->canvas = gui_direct_draw_acquire(instance->gui);
+
+    instance->input_subscription =
+        furi_pubsub_subscribe(instance->input, gui_input_events_callback, instance);
+
+    return instance;
+}
+
+static void direct_draw_free(DirectDraw* instance) {
+    furi_pubsub_unsubscribe(instance->input, instance->input_subscription);
+
+    instance->canvas = NULL;
+    gui_direct_draw_release(instance->gui);
+    furi_record_close(RECORD_GUI);
+    furi_record_close(RECORD_INPUT_EVENTS);
+}
+
+static void direct_draw_run(DirectDraw* instance) {
+    size_t start = DWT->CYCCNT;
+    size_t counter = 0;
+    float fps = 0;
+
+    furi_thread_set_current_priority(FuriThreadPriorityIdle);
+
+    do {
+        size_t elapsed = DWT->CYCCNT - start;
+        char buffer[BUFFER_SIZE] = {0};
+
+        if(elapsed >= SystemCoreClock) {
+            fps = (float)counter / ((float)elapsed / SystemCoreClock);
+
+            start = DWT->CYCCNT;
+            counter = 0;
+        }
+        snprintf(buffer, BUFFER_SIZE, "FPS: %.1f", (double)fps);
+
+        // Here we would normally be doing some more complex rendering.
+        // For this example, fill the bottom 3/4 of the screen with a thick checkerboard pattern
+        // just to have -some- processing going on.
+        {
+            uint8_t* back_buffer = instance->screen_buffer + 2 * 128;
+            for(uint32_t y = 16; y < 64; ++y) {
+                if((y % 32) == 16) {
+                    back_buffer += 2;
+                } else if((y % 32) == 0) {
+                    back_buffer -= 2;
+                }
+
+                for(uint32_t x = 0; x < 128; x += 32) {
+                    *back_buffer++ = 0xFF;
+                    *back_buffer++ = 0xFF;
+                    back_buffer += 2;
+                }
+            }
+        }
+
+        canvas_blit_fast(instance->canvas, instance->screen_buffer);
+        //canvas_draw_xbm(instance->canvas, 0, 0, 128, 64, instance->screen_buffer);
+
+        canvas_draw_str(instance->canvas, 10, 10, buffer);
+        canvas_commit(instance->canvas);
+
+        counter++;
+
+        furi_thread_yield();
+
+    } while(!instance->stop);
+}
+
+int32_t fast_blit_demo_app(void* p) {
+    UNUSED(p);
+
+    DirectDraw* instance = direct_draw_alloc();
+    direct_draw_run(instance);
+    direct_draw_free(instance);
+
+    return 0;
+}
+```
+</details>
+
+Currently, `canvas_draw_xbm` is used for tasks like this. However, u8g2 proves itself quite inefficient for a task like this that should be a glorified memcpy - instead, u8g2 appears to be drawing bit by bit.
+
+For my proof-of-concept, I exposed `canvas_get_buffer()` to the public API. However, the memory returned by this function is tiled and therefore not user-friendly, so exposing this function is not a solution to the problem. Instead, I suggest introducing a new `blit` function that does the swizzle and assignment internally, nothing else.
+
+I benchmarked both solutions on this app, and the results (on a `COMPACT=1` build) are as follows:
+* `canvas_draw_xbm` - 39.0FPS
+* `canvas_blit_fast` - ~194FPS
+
+In a real app, the gain of `blit_fast` would likely be slightly smaller, as the call got inlined in my sample app and I have not profiled it with `noinline`. Regardless, it should still be substantial, as the function would still be subject to loop unrolling/other optimizations when part of the firmware.
+
+### Anything else?
+
+I'm not pressed on this being the only "correct" solution. A few other things come to mind:
+* `canvas_draw_xbm` could be special-cased for fullscreen draws to do something like this.
+* If compatibility with color/alpha modes is necessary, the assignment can be trivially changed from `=` to `^=` or `|=`, depending on the combination of those modes. That said, I think it would be beneficial to have a function that guarantees a copy as-is, hence the idea to differentiate `draw` functions (respecting the u8g2 state) and `blit` functions (ignoring that state by design).
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03436-flipper-zero-crashes-when-i-try-to-use-it.-readin.md
+++ b/.ai/upstream-issues/03436-flipper-zero-crashes-when-i-try-to-use-it.-readin.md
@@ -1,0 +1,148 @@
+# Issue #3436: Flipper Zero Crashes when I try to use it. (Reading NFC, Saving IR Remote Sequences)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3436](https://github.com/flipperdevices/flipperzero-firmware/issues/3436)
+**Author:** @I-Am-Skoot
+**Created:** 2024-02-09T14:28:08Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+I had to replace a lost device.   Since then the new device has been consistently crashing.  This has been over the last 3 firmware versions, so I am inclined to believe it is a hardware issue, however the support team insisted I open a ticket here.
+
+
+
+### Reproduction
+
+1. Switch on the device
+2.1. Open the NFC app
+2.1 Read Card
+2.2 Place flipper against card
+2.3 Crash
+2.2 Open cross remote app
+2.3 Create a new sequence
+2.4 start adding entries
+2.5 Crash
+
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+_.-------.._                    -,
+          .-""--..,,_/ /`-,               -,  \
+       .:"          /:/  /'\  \     ,_...,  `. |  |
+      /       ,----/:/  /`\ _\~`_-"`     _;
+     '      / /`"""'\ \ \.~`_-'      ,-"'/
+    |      | |  0    | | .-'      ,/`  /
+   |    ,..\ \     ,.-"`       ,/`    /
+  ;    :    `/`""\`           ,/--==,/-----,
+  |    `-...|        -.___-Z:_______J...---;
+  :         `                           _-'
+ _L_  _     ___  ___  ___  ___  ____--"`___  _     ___
+| __|| |   |_ _|| _ \| _ \| __|| _ \   / __|| |   |_ _|
+| _| | |__  | | |  _/|  _/| _| |   /  | (__ | |__  | |
+|_|  |____||___||_|  |_|  |___||_|_\   \___||____||___|
+
+Welcome to Flipper Zero Command Line Interface!
+Read Manual https://docs.flipperzero.one
+
+Firmware version: 0.96.1 0.96.1 (5dbe1cf0 built on 08-12-2023)
+
+>: log debug
+Current log level: debug
+Use <log ?> to list available log levels
+Press CTRL+C to stop...
+340848 [I][Loader] Loading /ext/apps/NFC/nfc.fap
+340980 [I][Elf] Total size of loaded sections: 53013
+340982 [I][Loader] Loaded in 134ms
+340985 [I][AnimationManager] Unload animation 'L1_Waves_128x50'
+342355 [D][NfcScanner] Found 5 base protocols
+342363 [D][DolphinState] icounter 1, butthurt 0
+342377 [D][Nfc] FWT Timeout
+342404 [D][Nfc] FWT Timeout
+342429 [D][Nfc] FWT Timeout
+342481 [D][Nfc] FWT Timeout
+342509 [D][Nfc] FWT Timeout
+342532 [D][Nfc] FWT Timeout
+342579 [D][Nfc] FWT Timeout
+342604 [D][Nfc] FWT Timeout
+342667 [D][Nfc] FWT Timeout
+342695 [D][Nfc] FWT Timeout
+342718 [D][Nfc] FWT Timeout
+342743 [D][Nfc] FWT Timeout
+342768 [D][Nfc] FWT Timeout
+342820 [D][Nfc] FWT Timeout
+342848 [D][Nfc] FWT Timeout
+342871 [D][Nfc] FWT Timeout
+342907 [D][Nfc] FWT Timeout
+342932 [D][Nfc] FWT Timeout
+342984 [D][Nfc] FWT Timeout
+343012 [D][Nfc] FWT Timeout
+343035 [D][Nfc] FWT Timeout
+343060 [D][Nfc] FWT Timeout
+343085 [D][Nfc] FWT Timeout
+343137 [D][Nfc] FWT Timeout
+343165 [D][Nfc] FWT Timeout
+343188 [D][Nfc] FWT Timeout
+343213 [D][Nfc] FWT Timeout
+343238 [D][Nfc] FWT Timeout
+343291 [D][Nfc] FWT Timeout
+343319 [D][Nfc] FWT Timeout
+343342 [D][Nfc] FWT Timeout
+343367 [D][Nfc] FWT Timeout
+343392 [D][Nfc] FWT Timeout
+343444 [D][Nfc] FWT Timeout
+343472 [D][Nfc] FWT Timeout
+343495 [D][Nfc] FWT Timeout
+343520 [D][Nfc] FWT Timeout
+343545 [D][Nfc] FWT Timeout
+343608 [D][Nfc] FWT Timeout
+343638 [D][Nfc] FWT Timeout
+343663 [D][Nfc] FWT Timeout
+343688 [D][Nfc] FWT Timeout
+343713 [D][Nfc] FWT Timeout
+343765 [D][Nfc] FWT Timeout
+343793 [D][Nfc] FWT Timeout
+343816 [D][Nfc] FWT Timeout
+343841 [D][Nfc] FWT Timeout
+343866 [D][Nfc] FWT Timeout
+343940 [D][Nfc] FWT Timeout
+343968 [D][Nfc] FWT Timeout
+343991 [D][Nfc] FWT Timeout
+344016 [D][Nfc] FWT Timeout
+344041 [D][Nfc] FWT Timeout
+344093 [D][Nfc] FWT Timeout
+344121 [D][Nfc] FWT Timeout
+344180 [D][Nfc] FWT Timeout
+344206 [D][Nfc] FWT Timeout
+344269 [D][Nfc] FWT Timeout
+344297 [D][Nfc] FWT Timeout
+344312 [D][NfcScanner] Found 4 children
+344369 [D][Nfc] FWT Timeout
+344371 [D][Nfc] FWT Timeout
+344405 [D][Nfc] FWT Timeout
+344438 [D][Iso14443_4aPoller] Read ATS success
+344470 [I][NfcScanner] Detected 1 protocols
+344602 [D][Iso14443_4aPoller] Read ATS success
+344612 [D][MfDesfirePoller] Read version success
+344616 [D][MfDesfirePoller] Read free memory success
+344620 [D][MfDesfirePoller] Read master key settings success
+344625 [D][MfDesfirePoller] Read master key version success
+344630 [D][MfDesfirePoller] Read application ids success
+```
+
+
+### Anything else?
+
+I made a video of the issues
+
+[![IMAGE ALT TEXT](http://img.youtube.com/vi/kWmxJfC7YiQ/0.jpg)](http://www.youtube.com/watch?v=kWmxJfC7YiQ "Flipper Crash")
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03454-nfc--bus-card-cant-be-emulated.-only-scanned..md
+++ b/.ai/upstream-issues/03454-nfc--bus-card-cant-be-emulated.-only-scanned..md
@@ -1,0 +1,63 @@
+# Issue #3454: NFC: (Bus card) Cant be emulated. Only scanned.
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3454](https://github.com/flipperdevices/flipperzero-firmware/issues/3454)
+**Author:** @Killer74-hub
+**Created:** 2024-02-16T16:21:13Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+
+![Screenshot-20240216-175623](https://github.com/flipperdevices/flipperzero-firmware/assets/126610656/58514f04-9ddb-4e60-8acf-d1c7375a3b22)
+![Screenshot-20240216-175616](https://github.com/flipperdevices/flipperzero-firmware/assets/126610656/baa86ea3-47a8-4ad2-b3bb-ab4de19b892b)
+### Describe the bug.
+
+The Card is this card: https://www.rmv.de/c/en/tickets/your-ticket/tickets-overview/annual-season-tickets
+
+It is a german Bus ticket.
+
+### Reproduction
+
+1. Clone Card
+2. Save the Card/Emulate Directly
+3. Emulate the card
+
+### Target
+
+German Bus Card(NFC)
+
+### Logs
+
+```Text
+Filetype: Flipper NFC device
+Version: 4
+# Device type can be ISO14443-3A, ISO14443-3B, ISO14443-4A, ISO14443-4B, ISO15693-3, FeliCa, NTAG/Ultralight, Mifare Classic, Mifare DESFire, SLIX, ST25TB
+Device type: ISO14443-4A
+
+
+
+scanned: 
+
+
+72249131 [D][NfcScanner] Found 4 children
+72249188 [D][Nfc] FWT Timeout
+72249190 [D][Nfc] FWT Timeout
+72249224 [D][Nfc] FWT Timeout
+72249257 [D][Iso14443_4aPoller] Read ATS success
+72249278 [I][NfcScanner] Detected 1 protocols
+72249413 [D][Iso14443_4aPoller] Read ATS success
+72249647 [D][DolphinState] icounter 555, butthurt 0
+
+
+(I will give you the rest through discord if you need it. contact me.)
+```
+
+
+### Anything else?
+
+Contact me through Discord if you want the NFC Card number/ more screenshots. I don´t want to give it to the public. 
+
+discord: sniper74
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03455-non-important-ui-changes.md
+++ b/.ai/upstream-issues/03455-non-important-ui-changes.md
@@ -1,0 +1,37 @@
+# Issue #3455: Non-Important UI changes
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3455](https://github.com/flipperdevices/flipperzero-firmware/issues/3455)
+**Author:** @Tomi2965
+**Created:** 2024-02-16T19:57:55Z
+**Labels:** Feature Request, UI
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Some non-important ideas for make FZ a bit better. 
+
+After a uSD card is removed without unmount procedure, show warning message, or better, message with sad Flipper image. After remove uSD card with unmount procedure, show notice, or notice with happy Flipper (educational way to always use unmount).
+
+Unmount uSD card - allow to link Fav App button to this function, or, on dev FW's add function to FZ info screen (on desktop long press down). On FZ info just again long press down for legal unmount.
+
+Power off - for now a sad Flipper is shown. After power on, add a happy Flipper screen. On dev FW's disable sad Flipper, or add a "working" Flipper. 
+
+Settings - LCD and notifications - LED Brightness - on hover on this - turn on LED and leave it on until row is changed, and allow user to properly verify LED brightness. On "Vibro" - when set "ON", turn on vibration for at least one second (or apply two short vibrates). Current vibro time on set on is so short.
+
+Settings - System - Date Format: option "D/M/Y" is not good. Slashes are used on US "M/D/Y". Please change "D/M/Y" to "D.M.Y" for make date format exact.
+
+Many thanks for any comments, fixes, ... . :) 
+
+
+
+
+
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03491-allow-duplicating-modifying-nfc-v---iso-15693-tags.md
+++ b/.ai/upstream-issues/03491-allow-duplicating-modifying-nfc-v---iso-15693-tags.md
@@ -1,0 +1,26 @@
+# Issue #3491: Allow duplicating/modifying NFC-V / ISO 15693 tags to get write new lifeionizers NFC tags
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3491](https://github.com/flipperdevices/flipperzero-firmware/issues/3491)
+**Author:** @marcmerlin
+**Created:** 2024-03-01T16:07:37Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+I have a water filter that reads NFC-V tags to see if I put a new filter in (and force me to keep buying more even if replacement is not actually needed yet).  It's a LIFE IONIZER MXL-9 ALKALINE WATER IONIZER from lifeionizers.com (to help google searches get here).
+Flipper zero can read the NFC-V tag and emulate it, but what I actually need it to do is to read the tag and allow me to rewrite it on a blank tag.  I have bought these: 
+NXP iCode SLIX Tag,ISO/IEC 15693 HF,RFID Library Labels (Pack of 20)  https://www.amazon.com/gp/product/B0755WF6CK
+but flipper zero does not seem to allow to rewrite/duplicate a tag in the case of NFC-V.
+I should add that in this specific case, I'm not actually actually trying to duplicate the tag exactly but will want to modify a few bytes (maybe just the serial number, or a few bytes in the payload) to have the water filter think it's a new filter and work again.
+More info for anyone curious: the water filter will refuse to work if too many liters have been filtered (which is fair enough), but also will time out a filter after about a year of clock time, even if it's barely been used and that's the bad part. I did find a workaround where putting in another filter resets the clock time on the new filter and then later also allows reusing the first filter (it remembers how many liters for the last few filters, but not how many days of use, so that gets reset).
+That workaround is helpful, but having flipper zero allow me to write new tags after editting a few bytes, would be even better.
+As for the last question: how could I have the new tag be read: the filter fits in 2 ways, one direction has no tag and the other direction has the embedded tag. I woudl somply glue the new tag on the other side and put the filter that way, the old tag would be too far and the new tag would be read.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03494-keri-rfid-nxt-not-reading.md
+++ b/.ai/upstream-issues/03494-keri-rfid-nxt-not-reading.md
@@ -1,0 +1,13 @@
+# Issue #3494: Keri RFID NXT not reading
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3494](https://github.com/flipperdevices/flipperzero-firmware/issues/3494)
+**Author:** @devopgirlie
+**Created:** 2024-03-04T01:09:03Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+Keri key fob NXT series (starts with N before serial number) does not read under RFID or NFC. Unable to get a RAW read as well. Is there a fix to this issue? Thanks in advance
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03534-api-request--free-heap-blocks-available-same-as-m.md
+++ b/.ai/upstream-issues/03534-api-request--free-heap-blocks-available-same-as-m.md
@@ -1,0 +1,25 @@
+# Issue #3534: API request: Free heap blocks available (same as memmgr_heap_printf_free_blocks)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3534](https://github.com/flipperdevices/flipperzero-firmware/issues/3534)
+**Author:** @noproto
+**Created:** 2024-03-21T16:55:25Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Currently there's no way to check all of the available heap blocks of memory via the API.
+
+It's not possible to plan heap allocation without repeatedly reserving memory and checking the next largest block with memmgr_heap_get_max_free_block (and if there's insufficient memory rolling back all of the allocations and re-allocating).
+
+The only way I can see (which is a hack) is by setting up a log handler with furi_log_add_handler, call memmgr_heap_printf_free_blocks to dump the free blocks to the log buffered output stream, read back the log and parse each line, then use that in any heap memory planning function.
+
+It would be very helpful to expose a function which can be used to plan help allocation/memory management in FAPs. If the largest sized block isn't checked, any malloc can fail freezing the device.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03566-mifare-desfire-emulate-uid-not-working.md
+++ b/.ai/upstream-issues/03566-mifare-desfire-emulate-uid-not-working.md
@@ -1,0 +1,37 @@
+# Issue #3566: Mifare DESFire Emulate UID not working
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3566](https://github.com/flipperdevices/flipperzero-firmware/issues/3566)
+**Author:** @Fabunator
+**Created:** 2024-04-03T05:57:13Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+I have a copy of my woking place badge from Version 0.97.x
+In this version i could emulate the UID and use this to log into my work.
+In version 0.99.1 this is not possible any more.
+I also made a new copy with the current version but nothing changed.
+
+The type of the Tag is ISO14443-3A (Mifare DESFire EV1 4k) in the nfc file the type is Mifare DESFire 
+
+### Reproduction
+
+Read NFC Mifare DESFire Tag
+Emulate UID
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03591-password-protection-for-t55xx.md
+++ b/.ai/upstream-issues/03591-password-protection-for-t55xx.md
@@ -1,0 +1,19 @@
+# Issue #3591: Password protection for T55xx
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3591](https://github.com/flipperdevices/flipperzero-firmware/issues/3591)
+**Author:** @mxcdoam
+**Created:** 2024-04-15T19:00:27Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I'm talking about intercom keys. In my area it is a common countermeasure of service providers, to check if the tag is writeable. If intercom detects T55xx, it damages the tag (probably writing zeros as UID + locking or password protecting. That way tag cannot be detected and generally reused anymore). But it seems that tags password-protected by me are not detected as clones and continue to work. Right now flipper zero cannot protect tags, so I was wondering if it's possible to add this feature?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03593-suggestion-add-xp-lvl-up-xp.md
+++ b/.ai/upstream-issues/03593-suggestion-add-xp-lvl-up-xp.md
@@ -1,0 +1,21 @@
+# Issue #3593: Suggestion Add xp/lvl up xp
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3593](https://github.com/flipperdevices/flipperzero-firmware/issues/3593)
+**Author:** @santi00001
+**Created:** 2024-04-16T06:03:49Z
+**Labels:** Feature Request, UI, Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Suggestion "add xp/total xp till next level up" to the passport so I can see more accurately when my dolphin evolves but in the default firmware
+
+### Anything else?
+
+Would love to know any updates my discord is 
+@cowie000
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03599-suggestion--add-nfc-tag-writing-wiping-option-in-t.md
+++ b/.ai/upstream-issues/03599-suggestion--add-nfc-tag-writing-wiping-option-in-t.md
@@ -1,0 +1,19 @@
+# Issue #3599: Suggestion: Add NFC Tag Writing/wiping Option in the “More>” Menu (write to NFC Tag/wipe NFC Tag)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3599](https://github.com/flipperdevices/flipperzero-firmware/issues/3599)
+**Author:** @Killer74-hub
+**Created:** 2024-04-17T06:43:20Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+It would be nice to write info from an NFC Tag to another NFC Tag or have another option to delete something from an nfc tag(wipe nfc tag) . Is that possible?
+
+### Anything else?
+
+Maybe it would be nice to be able to override the old nfc codes
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03609-nfc-plugin-interface-expansions.md
+++ b/.ai/upstream-issues/03609-nfc-plugin-interface-expansions.md
@@ -1,0 +1,24 @@
+# Issue #3609: NFC Plugin Interface Expansions
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3609](https://github.com/flipperdevices/flipperzero-firmware/issues/3609)
+**Author:** @zacharyweiss
+**Created:** 2024-04-22T17:57:04Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Would there be interest in expanding the scope of NFC plugins? `read`, `verify`, and `parse` cover the base cases of course, but it's easy to imagine instances where one might wish to implement custom subscenes (eg, a better organized `parse` for cards with lots of data, rather than just one very long `FuriString`, like `nfc_scene_emv_more_info`) or custom submenu items for write / edit capabilities (eg, editing card values with the aid of known fields / field types / lookup values / etc).
+
+All of the above is of course achievable with custom, separate FAPs, but feels inelegant to have no way to integrate. Few possible integration approaches would be:
+- Addition of an optional `fap` field to the existing `NfcSupportedCardsPlugin` interface, linking a fully custom FAP (defined locally or as an EXT fap) that replaces / reimplements the `nfc_scene_saved_menu` and anything deeper into the menus. Exits back to NFC app. Most flexible, but maximal flexibility may not be desired for something intended as part of a `main` app.
+- Addition of dynamically attached menu item scenes, a la `nfc_protocol_support`'s `nfc_protocol_has_feature` branched menu logic, just with custom feature / submenu entry names. A middle road between a custom linked FAP for all specific-plugin-card logic, and completely prescribed scenes / methods. Would eliminate some duplicated code a fully custom FAP-per-expanded-NFC-plugin would call for.
+- A prescriptive format for the above additional use cases (expanded parsed output & custom write/edit methods), a la some unifying framework for specifying fields / field types / field value mappings for the sake of both parsing into sub-scenes & editing, as enabled / specified for each field designated. The most labor intensive, but would keep plugins the most "containerized" & uniform in format and scope.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03618-fdi-ipassan-mifare-plus-emulation-not-working.md
+++ b/.ai/upstream-issues/03618-fdi-ipassan-mifare-plus-emulation-not-working.md
@@ -1,0 +1,44 @@
+# Issue #3618: FDI iPassan Mifare Plus emulation not working
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3618](https://github.com/flipperdevices/flipperzero-firmware/issues/3618)
+**Author:** @Tomi2965
+**Created:** 2024-04-26T15:08:33Z
+**Labels:** NFC, Bug, Triage
+
+## Description
+
+### Describe the bug.
+
+Emulation of original FDI Mifare Plus tokens on FDI iPassan reader not works. In log is only half of UID (see images). Token is marked as Mifare Classic 1k
+
+![flpr-2024-04-26-17-00-12](https://github.com/flipperdevices/flipperzero-firmware/assets/152749132/80ab4abd-2cb8-47c1-b857-b41d1bb0ac50)
+Code readed on Flipper
+
+![Ipassan-1](https://github.com/flipperdevices/flipperzero-firmware/assets/152749132/3df6080a-ccec-4d0d-b305-1fb86eda30a6)
+Yellow line - emulated via FZ, green line - token readed by reader. 
+
+Note: please see, that FZ readed UID in reverse order. 
+
+Token model: FDI GB-010-230
+Reader model: FD-020-086
+
+If anybody need any beta-test, or any info, do not hesitate and just ask! I have one iPassan at home for testing (including destructive tests). 
+
+### Reproduction
+
+Emulation of original FDI Mifare Plus token on FDI reader
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+Have a nice day! :) 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03629-custom-crash-assert-messages-for-faps.md
+++ b/.ai/upstream-issues/03629-custom-crash-assert-messages-for-faps.md
@@ -1,0 +1,48 @@
+# Issue #3629: Custom crash/assert messages for FAPs
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3629](https://github.com/flipperdevices/flipperzero-firmware/issues/3629)
+**Author:** @CookiePLMonster
+**Created:** 2024-05-01T19:23:15Z
+**Labels:** Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+# Description
+
+The current implementations of `furi_check`, `furi_assert` and `furi_crash` allow the user to specify a custom crash message. This message is then displayed in serial logs, however, firmware-specified messages also come with an exclusive feature - [they are stored in the backup register and displayed on reboot](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/furi/core/check.c#L166-L170). Only a pointer is preserved, which means that for obvious reasons, this cannot be done for errors resided in the FAP.
+
+We've been brainstorming this with @Willy-JL and @kbembedded on Discord and came up with an idea that could use some more eyes on - because maybe it's reasonable, or maybe it's not viable and cannot be accepted. Either way, I'd be curious to hear an opinion about it.
+
+The idea would be to repurpose a few more backup registers (STM32WB55 has [20](https://github.com/STMicroelectronics/cmsis_device_wb/blob/d1b860584dfe24d40d455ae624ed14600dfa93c9/Include/stm32wb55xx.h#L9338), Flipper currently uses 7) to store a short (12-16 characters) arbitrary error message, so it can display on screen regardless whether it comes from firmware or FAP.
+
+# Example
+
+A revised "crash flow" accepting arbitrary 16-character error messages would then go as follows:
+1. Application calls `furi_crash("I crashed! Help!");`.
+2. In `__furi_crash_implementation`, a pointer range check is done as usual. If the error string pointer resides inside a firmware or is one of the in-built magic check/assert messages, **set the top bit of that pointer**. This will act as a marker for `furi_hal_rtc_get_fault_data`, signaling that `FuriHalRtcRegisterFaultData` stores a pointer and not a C string.
+3. If the string resides outside of the firmware, treat `FuriHalRtcRegisterFaultData`, `FuriHalRtcRegisterFaultData2`, `FuriHalRtcRegisterFaultData3` and `FuriHalRtcRegisterFaultData4` (added as part of this enhancement) as a `char[16]` buffer and `strncpy` the custom crash message into it. Since only ASCII is allowed, the top bit of `FuriHalRtcRegisterFaultData` remains cleared.
+4. On reboot, `furi_hal_rtc_get_fault_data` checks the top bit and returns a pointer to the in-firmware error string, or a pointer to the arbitrary message stored in the 4 backup registers. This might require the message to be copied out to a local `static char[17]` or something similar.
+
+# Benefits and risks
+
+Pros:
+1. Arbitrary messages can aid FAP debugging by the clever use of formatted messages - for example, one could devise a short assertion message with a line number and (part) of the filename.
+2. FAPs can opt to show user-friendly crash messages for some critical points of failure.
+3. No API version bump needed.
+
+Cons:
+1. Slightly increased code complexity.
+2. Increased usage of the backup registers.
+
+# Alternatives
+
+If backup registers are out of the question, is there perhaps a different place to store the message in? A writable section of the flash that the firmware could `strncpy` the error message to? A file in the internal storage?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03633-cant-read-nfc-tag.md
+++ b/.ai/upstream-issues/03633-cant-read-nfc-tag.md
@@ -1,0 +1,15 @@
+# Issue #3633: Cant read NFC tag
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3633](https://github.com/flipperdevices/flipperzero-firmware/issues/3633)
+**Author:** @iv-the-red
+**Created:** 2024-05-03T10:52:25Z
+**Labels:** NFC, Triage
+
+## Description
+
+I was trying to copy a card, but I got this error:![image-1.png](https://github.com/flipperdevices/flipperzero-firmware/assets/124264589/6e7ee29c-6273-49f7-92b5-046ba81d6584)
+
+ 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03638-nfc--equivalent-of-nfcworkereventsuccess-from-befo.md
+++ b/.ai/upstream-issues/03638-nfc--equivalent-of-nfcworkereventsuccess-from-befo.md
@@ -1,0 +1,15 @@
+# Issue #3638: NFC: Equivalent of NfcWorkerEventSuccess from before NFC refactor
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3638](https://github.com/flipperdevices/flipperzero-firmware/issues/3638)
+**Author:** @GMMan
+**Created:** 2024-05-06T19:42:50Z
+**Labels:** NFC, Triage
+
+## Description
+
+I'm finally getting around to updating my app that uses the old `NfcWorker` API to `NfcListener`, and I can't seem to find the equivalent of `NfcWorkerEventSuccess`. I was looking at `NfcEventTypeRxEnd` to add a hook for checking if something has changed, but it doesn't look like all events are propagated down to the callback fed to `nfc_listener_start()`. In particular, I'm using the Mifare Ultralight listener, and the only event it seems to propagate is `MfUltralightListenerEventTypeAuth`, which isn't very useful in my case. Is there some way I can detect that a write has occured to the emulated tag?
+
+Also, just to confirm, when checking data I should be using `nfc_listener_get_data()` and commit back to the NFC device using `nfc_device_set_data()`? ~~Or does the architecture guarantee that I can just use `nfc_device_get_data()` directly (with the same protocol specified in `nfc_listener_alloc()`, of course)?~~ Just noticed its `NfcDevice` is internal, so I'll definitely have to do something different...
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03641-nfc--furi_check_failed-crash-while-reading-mikron-.md
+++ b/.ai/upstream-issues/03641-nfc--furi_check_failed-crash-while-reading-mikron-.md
@@ -1,0 +1,34 @@
+# Issue #3641: NFC: furi_check_failed crash while reading MIKRON NFC on 0.101.2
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3641](https://github.com/flipperdevices/flipperzero-firmware/issues/3641)
+**Author:** @mxcdoam
+**Created:** 2024-05-08T18:23:16Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the bug.
+
+I get a crash while trying to read a card with MICRON JSC's implenetation of Ultralight: cards wich were not personalized (issued to an end user) are reporting to have 41 pages, and are read properly. Issued cards are reporting to have 16 pages and cause a crash on FW 0.101.2. I downgraded FZ to check those cards on FW 0.99.1, and both types (issued and not issued) were working properly and were not causing a crash. I've attached three dumps: 1)"Perso" aquired on 0.99.1, crashes 0.101.2, flipper recognize it as "Ultralight"; 2)Preperso aquired on 0.99.1, works fine, Fliper recognize it as "Ultralight 21"; 3) Same card as preperso aquired on 0.101.2.
+[FFF dumps.zip](https://github.com/flipperdevices/flipperzero-firmware/files/15253224/FFF.dumps.zip)
+
+
+### Reproduction
+
+Update FW to 0.101.2
+Try to read MIKRON NFC tag 
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03662-shareable-id.md
+++ b/.ai/upstream-issues/03662-shareable-id.md
@@ -1,0 +1,19 @@
+# Issue #3662: Shareable id
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3662](https://github.com/flipperdevices/flipperzero-firmware/issues/3662)
+**Author:** @robot-penguin34
+**Created:** 2024-05-23T03:37:22Z
+**Labels:** NFC, Sub-GHz, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+The flipper zero has a built in id to it, why not have the ability to share with NFC, and then recognize friends over subGHZ chat? Please consider this feature.
+
+### Anything else?
+
+Maybe have the ability to have a display name (not the default ID), and a very short description.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03667-feature-nfc-file-browser-improved-navigation.md
+++ b/.ai/upstream-issues/03667-feature-nfc-file-browser-improved-navigation.md
@@ -1,0 +1,25 @@
+# Issue #3667: Feature NFC File Browser improved navigation
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3667](https://github.com/flipperdevices/flipperzero-firmware/issues/3667)
+**Author:** @quarky42
+**Created:** 2024-05-27T18:01:52Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+When navigating a large library of NFCs organized by directories, when I go back (up one level in the directory structure) I want it to have the directory I was just in selected instead of starting the selection at the top of the screen. 
+
+The user work flow is to go into a directory, use a NFC file, go up to a higher level directory, press down one time, and select to go into the next directory in the list. 
+
+I should be able to repeat this procedure in order to go through all directories in order without having to scroll down all the way from the top to get into the next directory each time.
+
+This could and should be the default behavior for all file browsers but is evident to me in the NFC App when trying to cycle through multiple NFC files organized by directory name.
+
+### Anything else?
+
+Fixing the file navigation so that it remembers the directory or file you were in when returning to the navigation will make going through long lists of IR remotes and NFCs much easier and fewer clicks to navigate.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03677-a-javascript-module-for-handling-a-button-press.md
+++ b/.ai/upstream-issues/03677-a-javascript-module-for-handling-a-button-press.md
@@ -1,0 +1,40 @@
+# Issue #3677: A JavaScript module for handling a button press
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3677](https://github.com/flipperdevices/flipperzero-firmware/issues/3677)
+**Author:** @tlhunter
+**Created:** 2024-05-31T03:55:23Z
+**Labels:** Feature Request, JS
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I would like to request an API for receiving a single button press. This could be very similar to the existing dialogue API except that it wouldn't clear the screen or display any messages. The developer would be expected to draw to the screen ahead of time.
+
+The API could be very basic:
+
+```js
+let buttons = require("buttons");
+let result = buttons.waitForButtonPress();
+// result in "up", "down", "left", "right", "ok"
+```
+
+Ideally the back button could be caught as well but I understand that it is currently the only way to consistently exit a program and probably shouldn't be caught.
+
+Ideally, assuming the code runs inside of a loop, if the user were to hold down a button continuously then it would just work as expected, triggering the button press with each iteration.
+
+```js
+let buttons = require("buttons");
+while(true) {
+let result = buttons.waitForButtonPress();
+// result is read with each iteration even if button remains held
+// of course, there is no guaranteed timing...
+}
+```
+
+### Anything else?
+
+I believe this would unlock a lot of potential games.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03678-a-javascript-api-for-loading-and-drawing-from-a-sp.md
+++ b/.ai/upstream-issues/03678-a-javascript-api-for-loading-and-drawing-from-a-sp.md
@@ -1,0 +1,31 @@
+# Issue #3678: a JavaScript API for loading and drawing from a spritesheet
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3678](https://github.com/flipperdevices/flipperzero-firmware/issues/3678)
+**Author:** @tlhunter
+**Created:** 2024-05-31T04:10:50Z
+**Labels:** Feature Request, JS
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I would like to request a JavaScript API for opening a bitmap format representing graphics and for drawing them to the screen. This is a powerful and efficient pattern for drawing graphics. 
+
+Basically each sprite in a spritesheet is perhaps 8x8 pixels while the overall sheet is perhaps 64x64 pixels. Then one programmatically chooses one of the sprites in the sheet and provides a coordinate to draw the sprite at.
+
+The API could look like this: 
+```js
+let sprites = require('spritesheet');
+let sheet = sprites.load('mysheet.bmp', 8, 8); // w, h
+sprites.drawToScreen(sheet, 3, 8, 16);
+```
+This draws the fourth entry (index 3 when 0 based) in the spritesheet to pixel coordinate x=8, y=16. The drawn entry is 8x8 pixels.
+
+I used bmp as an example but it could be gif or pcx or whatever format Flipper already uses.
+
+### Anything else?
+
+This would allow for interesting game development.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03687-125khz-fob-not-read---protocol-implementation.md
+++ b/.ai/upstream-issues/03687-125khz-fob-not-read---protocol-implementation.md
@@ -1,0 +1,37 @@
+# Issue #3687: 125kHz fob not read / Protocol implementation?
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3687](https://github.com/flipperdevices/flipperzero-firmware/issues/3687)
+**Author:** @WilliamHF
+**Created:** 2024-06-05T12:55:19Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Hi,
+
+Flipper cannot read a T5577 fob used for gate access. 
+
+The fob in itself is completely generic 
+![image](https://github.com/flipperdevices/flipperzero-firmware/assets/10669735/aa429cb1-c670-429f-b57f-1eabb88413ad)
+
+
+
+
+Attached are ASK/PSK raw reads. 
+[nvqnq.zip](https://github.com/user-attachments/files/15587181/nvqnq.zip)
+
+
+Any help in decoding is welcome and appreciated if doable!
+
+I have some additional fobs I can raw read if necessary to have multiple reads here.. 
+
+Thanks
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03704-il-region-sub-ghz-missing-allowed-frequencies.md
+++ b/.ai/upstream-issues/03704-il-region-sub-ghz-missing-allowed-frequencies.md
@@ -1,0 +1,46 @@
+# Issue #3704: IL region, sub-ghz missing allowed frequencies
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3704](https://github.com/flipperdevices/flipperzero-firmware/issues/3704)
+**Author:** @ypelech
+**Created:** 2024-06-12T11:49:38Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Describe the bug.
+
+The allowed frequencies in IL region should be:
+314-314.9
+315
+325
+433.04-434.79
+915-917
+
+Link to official frequencies allocation: 
+the detailed frequency table by the ministery of communication (hebrew - didn't find it in english) - https://rfa.justice.gov.il/SearchPredefinedApi/Documents/IdngyMn~ojdQSrkxuAqfZqiM8c1foi3TSZQhp7OMszo=
+
+starting from page 16 in the PDF.
+
+Thank you.
+
+ 
+
+
+### Reproduction
+
+blocked by definition in the IL region.
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03752-lfrfid--indala-e9-support.md
+++ b/.ai/upstream-issues/03752-lfrfid--indala-e9-support.md
@@ -1,0 +1,20 @@
+# Issue #3752: LFRFID: Indala E9 Support
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3752](https://github.com/flipperdevices/flipperzero-firmware/issues/3752)
+**Author:** @vineet4183
+**Created:** 2024-07-04T08:10:41Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Hi,
+Can support for Indala E9 cards be added to firmware?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03755-cc1101--impossible-to-send-a-long-preamble.md
+++ b/.ai/upstream-issues/03755-cc1101--impossible-to-send-a-long-preamble.md
@@ -1,0 +1,73 @@
+# Issue #3755: CC1101: Impossible to send a long preamble
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3755](https://github.com/flipperdevices/flipperzero-firmware/issues/3755)
+**Author:** @krzys-h
+**Created:** 2024-07-05T07:36:23Z
+**Labels:** Sub-GHz, Bug
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Hi! I'm currently trying to replicate a [custom base station for old electronic price tags](https://github.com/atc1441/E-Paper_Pricetags/tree/main/Custom_PriceTag_AccesPoint) using a Flipper. Since these tags use the CC1110 chip (the variant of CC1101 integrated with a 8051 MCU), they should be a perfect match for the CC1101 in the Flipper. However, since the communication protocol is quite a bit more complicated than what the Flipper usually deals with, I'm running into some limitations of the software API interface exposed to the applications.
+
+The price tags I'm working with use a very peculiar battery saving measure. When not in use, they shut down completely, including the radio. Every 15 seconds or so, they wake up, check the wakeup channels for presence of a carrier (there are two, one for the EU and one for the US), and if nothing is transmitting, immediately go back to sleep. To wake them up, you need to start transmitting on the frequency, sleep for 15 seconds or so to ensure the tag has woken up, and only then send the actual packet.
+
+According to some other implementation I'm referencing and the CC1101 datasheet, the way to achieve this is to first switch the chip to TX mode, which will immediately start transmitting the preamble on the frequency, and send the packet after some time when we actually want to start transmitting.
+
+<details>
+<summary>Quote from the CC1101 datasheet</summary>
+
+> The preamble pattern is an alternating
+> sequence of ones and zeros (10101010…).
+> The minimum length of the preamble is
+> programmable through the value of
+> MDMCFG1.NUM_PREAMBLE. When enabling
+> TX, the modulator will start transmitting the
+> preamble. When the programmed number of
+> preamble bytes has been transmitted, the
+> modulator will send the sync word and then
+> data from the TX FIFO if data is available. If
+> the TX FIFO is empty, the modulator will
+> continue to send preamble bytes until the first
+> byte is written to the TX FIFO. The modulator
+> will then send the sync word and then the data
+> bytes. 
+</details>
+
+On the Flipper, you would expect this to translate to something along the lines of:
+```c
+subghz_devices_set_tx(device);
+for(int i = 15; i > 0; i--) {
+    FURI_LOG_I(TAG, "%d", i);
+    furi_delay_ms(1000);
+}
+uint8_t wakeup_packet[10] = { ... data ... };
+subghz_devices_write_packet(device, wakeup_packet, 10);
+```
+
+This, however, does not work, and the radio chip stops transmitting the preamble and enters the `IDLE` state when `subghz_devices_write_packet` is called. This is because this function internally causes the `SFTX` strobe to be sent, which is technically undefined behavior, as the datasheet specifies that it can only be called while in `IDLE` or `TX_UNDERFLOW` states.
+
+```c
+void furi_hal_subghz_write_packet(const uint8_t* data, uint8_t size) {
+    furi_check(data);
+    furi_check(size);
+
+    furi_hal_spi_acquire(&furi_hal_spi_bus_handle_subghz);
+    cc1101_flush_tx(&furi_hal_spi_bus_handle_subghz);     // <---- problem here
+    cc1101_write_reg(&furi_hal_spi_bus_handle_subghz, CC1101_FIFO, size);
+    cc1101_write_fifo(&furi_hal_spi_bus_handle_subghz, data, size);
+    furi_hal_spi_release(&furi_hal_spi_bus_handle_subghz);
+}
+```
+
+I'm not sure what the best way to fix this without breaking backwards compatibility of the interface would be, but I definitely wouldn't expect the `write_packet` function to switch radio modes.
+
+As far as I can tell, the firmware doesn't expose any more direct `cc1101_*` routines to the applications, so to workaround this you need to copy a few of the functions into the app and control the SPI bus pretty much directly (ouch).
+
+### Anything else?
+
+`read_packet` does not have this problem, and flushing the FIFO is left up to the application.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03756-flipper-crashes-when-continuously-opening-and-clos.md
+++ b/.ai/upstream-issues/03756-flipper-crashes-when-continuously-opening-and-clos.md
@@ -1,0 +1,80 @@
+# Issue #3756: Flipper crashes when continuously opening and closing the Passport screen
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3756](https://github.com/flipperdevices/flipperzero-firmware/issues/3756)
+**Author:** @CookiePLMonster
+**Created:** 2024-07-05T14:18:18Z
+**Labels:** Bug, Core+Services
+
+## Description
+
+### Describe the bug.
+
+When the user continuously presses DPad Right and Back buttons to spam opening and closing the Passport app, `furi_check` eventually triggers. I found it to be the easiest to reproduce on a Senpai animation.
+
+### Reproduction
+
+1. Press DPad Right.
+2. Immediately press Back without giving the Passport app the chance to open.
+3. Repeat until `furi_check` triggers.
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+25703 [I][Loader] App returned: 0
+25704 [I][Loader] Application stopped. Free heap: 144896
+26464 [I][AnimationManager] Select 'L1_Senpai_128x64' animation
+26470 [I][AnimationManager] Load animation 'L1_Senpai_128x64'
+26496 [I][SavedStruct] Loading "/int/.desktop.settings"
+31916 [I][SavedStruct] Loading "/int/.desktop.settings"
+31924 [I][Loader] Starting Passport
+31926 [I][AnimationManager] Unload animation 'L1_Senpai_128x64'
+32051 [D][GuiSrv] ViewPort changed while key press 2000A708 -> 20009370. Discarding key: Back, type: Short, sequence: 00000024
+32057 [D][GuiSrv] ViewPort changed while key press 2000A708 -> 20009370. Sending key: Back, type: Release, sequence: 00000024 to previous view port
+32427 [I][Loader] App returned: 0
+32428 [I][Loader] Application stopped. Free heap: 144920
+33202 [W][ViewPort] ViewPort lockup: see applications\services\gui\view_port.c:185
+33205 [I][AnimationManager] Select 'L1_Senpai_128x64' animation
+33209 [I][AnimationManager] Load animation 'L1_Senpai_128x64'
+33214 [W][ViewPort] ViewPort lockup: see applications\services\gui\view_port.c:185
+33217 [I][SavedStruct] Loading "/int/.desktop.settings"
+33227 [I][SavedStruct] Loading "/int/.desktop.settings"
+33245 [I][SavedStruct] Loading "/int/.desktop.settings"
+33250 [I][Loader] Starting Passport
+33266 [I][SavedStruct] Loading "/int/.desktop.settings"
+33787 [W][ViewPort] ViewPort lockup: see applications\services\gui\view_port.c:185
+
+[CRASH][LoaderSrv] furi_check failed
+r0 : fffffffe
+r1 : 0
+r2 : 2000024c
+r3 : 0
+r4 : 20005838
+r5 : 20011ee0
+r6 : 20038f7c
+r7 : 0
+r8 : a5a5a5a5
+r9 : a5a5a5a5
+r10 : a5a5a5a5
+r11 : 20031364
+lr : 807754b
+stack watermark: 1108
+     heap total: 185536
+      heap free: 118512
+heap watermark: 89512
+core2: not faulted
+System halted. Connect debugger for more info
+```
+
+
+### Anything else?
+
+The check is triggered with a `furi_semaphore_acquire` from `desktop_loader_callback` timing out. By adding additional logging I found out that when it crashes, `DesktopGlobalBeforeAppStarted` does not even begin processing, and therefore does not release the semaphore on time. My suspicion is that the view dispatcher queue, while not full (as `view_dispatcher_send_custom_event(desktop->view_dispatcher, DesktopGlobalBeforeAppStarted);` went through), is probably busy processing other kind of events and does not get to processing `DesktopGlobalBeforeAppStarted` in time.
+
+Looking at the logs spamming `[I][SavedStruct] Loading "/int/.desktop.settings"` just before the crash, maybe the desktop reloads multiple times in those conditions? I also verified with additional logging that by the time it crashes, `DesktopGlobalAfterAppFinished` is **also** not being processed.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03772-mifare-ultralight-c-hex-dump-shows-bogus-data-for-.md
+++ b/.ai/upstream-issues/03772-mifare-ultralight-c-hex-dump-shows-bogus-data-for-.md
@@ -1,0 +1,33 @@
+# Issue #3772: MIFARE Ultralight C hex dump shows bogus data for locked pages
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3772](https://github.com/flipperdevices/flipperzero-firmware/issues/3772)
+**Author:** @supersat
+**Created:** 2024-07-09T00:26:47Z
+**Labels:** NFC, UI, Triage
+
+## Description
+
+### Describe the bug.
+
+At a recent event, we gave everyone MIFARE Ultralight C wristbands with some pages locked as part of a CTF. Many people tried reading their wristband with their Flipper Zero, and unfortunately, rather than seeing some pages locked in the hex dump, they saw bogus data (seemingly copied starting from page 0). The NXP TagInfo app for Android correctly showed those pages as XX XX XX XX.
+
+### Reproduction
+
+1. Auth-protect some pages on a MIFARE Ultralight C card. This can be done by writing 25 00 00 00 to page 0x2a and 00 00 00 00 to page 0x2b. This locks pages 0x25 and up from being read without authentication.
+2. Read the tag with the Flipper Zero.
+3. Select Info, then more, then scroll down to the bottom. The last 3 pages should show as locked, but are copies of pages 0, 1, and 2.
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+FW version 0.103.1
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03778-support-multiple-devices-for-bt-remote.md
+++ b/.ai/upstream-issues/03778-support-multiple-devices-for-bt-remote.md
@@ -1,0 +1,19 @@
+# Issue #3778: Support multiple devices for BT remote
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3778](https://github.com/flipperdevices/flipperzero-firmware/issues/3778)
+**Author:** @Kami-no
+**Created:** 2024-07-10T09:00:25Z
+**Labels:** Feature Request, Bluetooth
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I've multiple devices to control with BT remote. It would be nice to have menu with an option to switch BT profiles to connect to different devices.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03818-t5577-feature-request---dump---restore---compare-f.md
+++ b/.ai/upstream-issues/03818-t5577-feature-request---dump---restore---compare-f.md
@@ -1,0 +1,15 @@
+# Issue #3818: T5577 Feature Request - dump / restore / compare feature
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3818](https://github.com/flipperdevices/flipperzero-firmware/issues/3818)
+**Author:** @amalg
+**Created:** 2024-07-31T17:28:40Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+The low frequency T5577 chip is so versatile that even access control system manufacturers are using it over purchasing AWiD, EM, HID Prox, etc. LF chipsets, and replacement fob merchants are using them now too. Sometimes there are additional application data written to the T5577 and used by these systems than just their analog front-end configurations and ID data. This makes cloning the EM ID from a source T5577 to a fresh T5577 ineffective.
+
+A good feature would be to be able to perform a complete memory dump of a T5577 chip to the Flipper Zero, then be able to write this complete memory dump to a new T5577. This would include block 0 config data and any additional application data, thus making it a perfect clone. Additionally, it would be really nice to be able to compare a dump file to a tag to check / ensure the write process has completed successfully.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03821-rfid-read-problem-.md
+++ b/.ai/upstream-issues/03821-rfid-read-problem-.md
@@ -1,0 +1,21 @@
+# Issue #3821: RFID Read problem 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3821](https://github.com/flipperdevices/flipperzero-firmware/issues/3821)
+**Author:** @domthomas-dev
+**Created:** 2024-08-03T20:10:47Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Hello, I was unable to read to simulate this RFID key. I attach here the RAW files which were read without problems. Can we do something to make this work?
+
+### Anything else?
+
+[RfidRecord.zip](https://github.com/user-attachments/files/16482714/RfidRecord.zip)
+![IMG_4355](https://github.com/user-attachments/assets/328b8cca-545b-4279-ab20-850103b5126d)
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03825-c-breakpoints-not-hit.md
+++ b/.ai/upstream-issues/03825-c-breakpoints-not-hit.md
@@ -1,0 +1,149 @@
+# Issue #3825: C++ Breakpoints not hit
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3825](https://github.com/flipperdevices/flipperzero-firmware/issues/3825)
+**Author:** @janwiesemann
+**Created:** 2024-08-07T08:46:44Z
+**Labels:** Build System & Scripts, Core+Services
+
+## Description
+
+### Describe the bug.
+
+I'm currently trying to develop a small application for FZ. It utilizes some C++ Code and I would like to debug it. Sadly, it does not work. FreeRTOS and hardware close development is relatively new for me. I'm able to add C breakpoints. Yes, I could definitely write it in C but where is the fun in that?
+
+Any help or hint would be appreciated.
+
+### Setup:
+- JLink Mini EDU
+- VS-Code
+- fbt (application in `applications_user/`; not using ufbt)
+- firmware repo [release @ 0.104.0](https://github.com/flipperdevices/flipperzero-firmware/releases/tag/0.104.0)
+
+### Reproduction
+
+1. Create a new app
+2. Add some C++ code
+3. build it and try to attach a debugger to the application
+
+### Target
+
+f7 with VS-Code and C++
+
+### Logs
+**VS-Code Debug Console**
+```Text
+Cortex-Debug: VSCode debugger extension version 1.12.1 git(652d042). Usage info: https://github.com/Marus/cortex-debug#usage
+Reading symbols from /Users/user/Projects/flipper/flipperzero-firmware/toolchain/current/bin/arm-none-eabi-objdump --syms -C -h -w /Users/user/Projects/flipper/flipperzero-firmware/build/latest/firmware.elf
+Reading symbols from /Users/user/Projects/flipper/flipperzero-firmware/toolchain/current/bin/arm-none-eabi-nm --defined-only -S -l -C -p /Users/user/Projects/flipper/flipperzero-firmware/build/latest/firmware.elf
+Launching GDB: /Users/user/Projects/flipper/flipperzero-firmware/toolchain/current/bin/arm-none-eabi-gdb-py3 -q --interpreter=mi2
+    IMPORTANT: Set "showDevDebugOutput": "raw" in "launch.json" to see verbose GDB transactions here. Very helpful to debug issues or report problems
+Launching gdb-server: JLinkGDBServer -singlerun -nogui -if swd -port 50000 -swoport 50001 -telnetport 50002 -device STM32WB55RG -rtos GDBServer/RTOSPlugin_FreeRTOS.dylib
+    Please check TERMINAL tab (gdb-server) for output from JLinkGDBServer
+Finished reading symbols from objdump: Time: 42 ms
+Output radix now set to decimal 10, hex a, octal 12.
+Input radix now set to decimal 10, hex a, octal 12.
+Finished reading symbols from nm: Time: 767 ms
+vPortSuppressTicksAndSleep (expected_idle_ticks=30) at targets/f7/furi_hal/furi_hal_os.c:172
+172	        return;
+Program stopped, probably due to a reset and/or halt issued by debugger
+Firmware version on attached Flipper:
+	Version:     0.104.0
+	Built on:    24-07-2024
+	Git branch:  release
+	Git commit:  ee1b8b9f
+	Dirty:       False
+	HW Target:   7
+	Origin:      Official
+	Git origin:  git@github.com:user/flipperzero-firmware.git,https://github.com/flipperdevices/flipperzero-firmware.git
+Support for Flipper external apps debug is loaded
+Set 'build/latest/.extapps' as debug info lookup path for Flipper external apps
+Attaching to Flipper firmware
+[New Remote target]
+[New Thread 536882256]
+[New Thread 537080456]
+[New Thread 537081676]
+[New Thread 536882912]
+[New Thread 537106944]
+[New Thread 537072504]
+[New Thread 537085728]
+[New Thread 537083920]
+[New Thread 537085336]
+[New Thread 536950776]
+[New Thread 536886176]
+[New Thread 537073724]
+[New Thread 536910936]
+[New Thread 536909416]
+[New Thread 536884472]
+[New Thread 537085532]
+[New Thread 537074944]
+[New Thread 536890328]
+[New Thread 537084116]
+[New Thread 537079236]
+
+Thread
+3 received signal SIGTRAP, Trace/breakpoint trap.
+[Switching to Thread 536882256]
+vPortSuppressTicksAndSleep (expected_idle_ticks=86) at targets/f7/furi_hal/furi_hal_os.c:172
+172	        return;
+
+Thread
+3 received signal SIGTRAP, Trace/breakpoint trap.
+vPortSuppressTicksAndSleep (expected_idle_ticks=60) at targets/f7/furi_hal/furi_hal_os.c:172
+172	        return;
+[New Thread 536919432]
+
+Thread
+11 received signal SIGTRAP, Trace/breakpoint trap.
+[Switching to Thread 537085336]
+loader_start_external_app (error_message=0x2000c250, args=0x0, path=<optimized out>, storage=<optimized out>, loader=0x200066e0) at applications/services/loader/loader.c:530
+530	            __asm volatile("bkpt 0");
+New application loaded. Adding debug info
+Loading debug information from build/latest/.extapps/dolphin_jump_d.elf
+add symbol table from file "build/latest/.extapps/dolphin_jump_d.elf" at
+	.text_addr = 0x2000c75c
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7_S_copyEPcPKcj_addr = 0x2000c8f4
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEjjPKcj_addr = 0x2000d0cc
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1IS3_EEPKcRKS3__addr = 0x2000ce1c
+	.text._ZNSt15__new_allocatorIcE10deallocateEPcj_addr = 0x2000ab0c
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv_addr = 0x2000ca1c
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7replaceEjjPKcj_addr = 0x2000d25c
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEjjPKcj_addr = 0x2000cf04
+	.bss_addr = 0x2000c474
+	.rodata_addr = 0x2000d2ac
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7_S_moveEPcPKcj_addr = 0x2000cae4
+	.text._ZNSt15__new_allocatorIcE8allocateEjPKv_addr = 0x2000cb44
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERjj_addr = 0x2000cc34
+	.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPKcEEvT_S8_St20forward_iterator_tag_addr = 0x2000cc84
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEjjPKcj not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1IS3_EEPKcRKS3_ not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt15__new_allocatorIcE10deallocateEPcj not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7replaceEjjPKcj not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEjjPKcj not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt15__new_allocatorIcE8allocateEjPKv not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERjj not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+warning: section .text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPKcEEvT_S8_St20forward_iterator_tag not found in /Users/user/Projects/flipper/flipperzero-firmware/build/f7-firmware-C/.extapps/dolphin_jump_d.elf
+Failed to set debug mode: Cannot access memory at address 0x200009cc
+```
+
+**Full Build log**
+```
+rm -rf build/f7-firmware-C/.extapps/ && ./fbt COMPACT=1 DEBUG=0 VERBOSE=1 build APPSRC=applications_user/dolphin-jump/main.cpp
+
+arm-none-eabi-g++ -o build/f7-firmware-C/.extapps/dolphin_jump/Game.o -c -std=c++20 -fno-rtti -fno-use-cxa-atexit -fno-exceptions -fno-threadsafe-statics -ftemplate-depth=4096 -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-address-of-packed-member -Wredundant-decls -Wdouble-promotion -fdata-sections -ffunction-sections -fsingle-precision-constant -fno-math-errno -g -Os -mword-relocations -mlong-calls -fno-common -nostdlib -D_GNU_SOURCE -DFW_CFG_default -D"M_MEMORY_FULL(x)=abort()" -DSTM32WB -DSTM32WB55xx -DUSE_FULL_ASSERT -DUSE_FULL_LL_DRIVER -DMBEDTLS_CONFIG_FILE=\"mbedtls_cfg.h\" -DPB_ENABLE_MALLOC -DFW_ORIGIN_Official -DFURI_NDEBUG -DNDEBUG -DFAP_VERSION=\"0.1\" -Ifuri -Iapplications/services -Iapplications/main -Itargets/furi_hal_include -Itargets/f7/ble_glue -Itargets/f7/fatfs -Itargets/f7/furi_hal -Itargets/f7/inc -I. -Ilib -Ibuild/f7-firmware-C/assets/compiled -Ilib/mlib -Ilib/cmsis_core -Ilib/stm32wb_cmsis/Include -Ilib/stm32wb_hal/Inc -Ilib/stm32wb_copro/wpan -Ilib/drivers -Ilib/FreeRTOS-Kernel/include -Ilib/FreeRTOS-Kernel/portable/GCC/ARM_CM4F -Ilib/FreeRTOS-glue -Ilib/microtar/src -Ilib/mbedtls/include -Ilib/toolbox -Ilib/libusb_stm32/inc -Ilib/drivers -Ilib/flipper_format -Ilib/one_wire -Ilib/ibutton -Ilib/infrared/encoder_decoder -Ilib/infrared/worker -Ilib/littlefs -Ilib/subghz -Ilib/nfc -Ilib/digital_signal -Ilib/pulse_reader -Ilib/signal_reader -Ilib/app-scened-template -Ilib/callback-connector -Ilib/u8g2 -Ilib/lfrfid -Ilib/flipper_application -Ilib/music_worker -Ilib/mjs -Ilib/nanopb -Ilib/heatshrink -Ilib/ble_profile -Ilib/bit_lib -Ilib/datetime -Ibuild/f7-firmware-C/.extapps/dolphin_jump -Iapplications_user/dolphin-jump applications_user/dolphin-jump/Game.cpp
+python3 scripts/assets.py icons applications_user/dolphin-jump/images build/f7-firmware-C/.extapps/dolphin_jump --filename dolphin_jump_icons
+arm-none-eabi-g++ -o build/f7-firmware-C/.extapps/dolphin_jump/main.o -c -std=c++20 -fno-rtti -fno-use-cxa-atexit -fno-exceptions -fno-threadsafe-statics -ftemplate-depth=4096 -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-address-of-packed-member -Wredundant-decls -Wdouble-promotion -fdata-sections -ffunction-sections -fsingle-precision-constant -fno-math-errno -g -Os -mword-relocations -mlong-calls -fno-common -nostdlib -D_GNU_SOURCE -DFW_CFG_default -D"M_MEMORY_FULL(x)=abort()" -DSTM32WB -DSTM32WB55xx -DUSE_FULL_ASSERT -DUSE_FULL_LL_DRIVER -DMBEDTLS_CONFIG_FILE=\"mbedtls_cfg.h\" -DPB_ENABLE_MALLOC -DFW_ORIGIN_Official -DFURI_NDEBUG -DNDEBUG -DFAP_VERSION=\"0.1\" -Ifuri -Iapplications/services -Iapplications/main -Itargets/furi_hal_include -Itargets/f7/ble_glue -Itargets/f7/fatfs -Itargets/f7/furi_hal -Itargets/f7/inc -I. -Ilib -Ibuild/f7-firmware-C/assets/compiled -Ilib/mlib -Ilib/cmsis_core -Ilib/stm32wb_cmsis/Include -Ilib/stm32wb_hal/Inc -Ilib/stm32wb_copro/wpan -Ilib/drivers -Ilib/FreeRTOS-Kernel/include -Ilib/FreeRTOS-Kernel/portable/GCC/ARM_CM4F -Ilib/FreeRTOS-glue -Ilib/microtar/src -Ilib/mbedtls/include -Ilib/toolbox -Ilib/libusb_stm32/inc -Ilib/drivers -Ilib/flipper_format -Ilib/one_wire -Ilib/ibutton -Ilib/infrared/encoder_decoder -Ilib/infrared/worker -Ilib/littlefs -Ilib/subghz -Ilib/nfc -Ilib/digital_signal -Ilib/pulse_reader -Ilib/signal_reader -Ilib/app-scened-template -Ilib/callback-connector -Ilib/u8g2 -Ilib/lfrfid -Ilib/flipper_application -Ilib/music_worker -Ilib/mjs -Ilib/nanopb -Ilib/heatshrink -Ilib/ble_profile -Ilib/bit_lib -Ilib/datetime -Ibuild/f7-firmware-C/.extapps/dolphin_jump -Iapplications_user/dolphin-jump applications_user/dolphin-jump/main.cpp
+_validate_api_cache(["targets/f7/api_symbols.csv"], ["build/f7-firmware-C/sdk_origin.i"])
+arm-none-eabi-gcc -o build/f7-firmware-C/.extapps/dolphin_jump/dolphin_jump.o -c -std=gnu2x -Wstrict-prototypes -Wno-strict-prototypes -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-address-of-packed-member -Wredundant-decls -Wdouble-promotion -fdata-sections -ffunction-sections -fsingle-precision-constant -fno-math-errno -g -Os -mword-relocations -mlong-calls -fno-common -nostdlib -D_GNU_SOURCE -DFW_CFG_default -D"M_MEMORY_FULL(x)=abort()" -DSTM32WB -DSTM32WB55xx -DUSE_FULL_ASSERT -DUSE_FULL_LL_DRIVER -DMBEDTLS_CONFIG_FILE=\"mbedtls_cfg.h\" -DPB_ENABLE_MALLOC -DFW_ORIGIN_Official -DFURI_NDEBUG -DNDEBUG -DFAP_VERSION=\"0.1\" -Ifuri -Iapplications/services -Iapplications/main -Itargets/furi_hal_include -Itargets/f7/ble_glue -Itargets/f7/fatfs -Itargets/f7/furi_hal -Itargets/f7/inc -I. -Ilib -Ibuild/f7-firmware-C/assets/compiled -Ilib/mlib -Ilib/cmsis_core -Ilib/stm32wb_cmsis/Include -Ilib/stm32wb_hal/Inc -Ilib/stm32wb_copro/wpan -Ilib/drivers -Ilib/FreeRTOS-Kernel/include -Ilib/FreeRTOS-Kernel/portable/GCC/ARM_CM4F -Ilib/FreeRTOS-glue -Ilib/microtar/src -Ilib/mbedtls/include -Ilib/toolbox -Ilib/libusb_stm32/inc -Ilib/drivers -Ilib/flipper_format -Ilib/one_wire -Ilib/ibutton -Ilib/infrared/encoder_decoder -Ilib/infrared/worker -Ilib/littlefs -Ilib/subghz -Ilib/nfc -Ilib/digital_signal -Ilib/pulse_reader -Ilib/signal_reader -Ilib/app-scened-template -Ilib/callback-connector -Ilib/u8g2 -Ilib/lfrfid -Ilib/flipper_application -Ilib/music_worker -Ilib/mjs -Ilib/nanopb -Ilib/heatshrink -Ilib/ble_profile -Ilib/bit_lib -Ilib/datetime -Ibuild/f7-firmware-C/.extapps/dolphin_jump -Iapplications_user/dolphin-jump applications_user/dolphin-jump/dolphin_jump.c
+arm-none-eabi-gcc -o build/f7-firmware-C/.extapps/dolphin_jump/dolphin_jump_icons.o -c -std=gnu2x -Wstrict-prototypes -Wno-strict-prototypes -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-address-of-packed-member -Wredundant-decls -Wdouble-promotion -fdata-sections -ffunction-sections -fsingle-precision-constant -fno-math-errno -g -Os -mword-relocations -mlong-calls -fno-common -nostdlib -D_GNU_SOURCE -DFW_CFG_default -D"M_MEMORY_FULL(x)=abort()" -DSTM32WB -DSTM32WB55xx -DUSE_FULL_ASSERT -DUSE_FULL_LL_DRIVER -DMBEDTLS_CONFIG_FILE=\"mbedtls_cfg.h\" -DPB_ENABLE_MALLOC -DFW_ORIGIN_Official -DFURI_NDEBUG -DNDEBUG -DFAP_VERSION=\"0.1\" -Ifuri -Iapplications/services -Iapplications/main -Itargets/furi_hal_include -Itargets/f7/ble_glue -Itargets/f7/fatfs -Itargets/f7/furi_hal -Itargets/f7/inc -I. -Ilib -Ibuild/f7-firmware-C/assets/compiled -Ilib/mlib -Ilib/cmsis_core -Ilib/stm32wb_cmsis/Include -Ilib/stm32wb_hal/Inc -Ilib/stm32wb_copro/wpan -Ilib/drivers -Ilib/FreeRTOS-Kernel/include -Ilib/FreeRTOS-Kernel/portable/GCC/ARM_CM4F -Ilib/FreeRTOS-glue -Ilib/microtar/src -Ilib/mbedtls/include -Ilib/toolbox -Ilib/libusb_stm32/inc -Ilib/drivers -Ilib/flipper_format -Ilib/one_wire -Ilib/ibutton -Ilib/infrared/encoder_decoder -Ilib/infrared/worker -Ilib/littlefs -Ilib/subghz -Ilib/nfc -Ilib/digital_signal -Ilib/pulse_reader -Ilib/signal_reader -Ilib/app-scened-template -Ilib/callback-connector -Ilib/u8g2 -Ilib/lfrfid -Ilib/flipper_application -Ilib/music_worker -Ilib/mjs -Ilib/nanopb -Ilib/heatshrink -Ilib/ble_profile -Ilib/bit_lib -Ilib/datetime -Ibuild/f7-firmware-C/.extapps/dolphin_jump -Iapplications_user/dolphin-jump build/f7-firmware-C/.extapps/dolphin_jump/dolphin_jump_icons.c
+Using tempfile /var/folders/mj/qp601k_s0rx3cwsv6chm7_6h0000gn/T/tmp_yi0ce9y.lnk for command line:
+arm-none-eabi-g++ -o build/f7-firmware-C/.extapps/dolphin_jump_d.elf -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mlittle-endian -mthumb -Wl,--no-warn-rwx-segment -Wl,--wrap,fflush -Wl,--wrap,fflush_unlocked -Wl,--wrap,_fflush_r -Wl,--wrap,_fflush_unlocked_r -Wl,--wrap,printf -Wl,--wrap,printf_unlocked -Wl,--wrap,_printf_r -Wl,--wrap,_printf_unlocked_r -Wl,--wrap,putc -Wl,--wrap,putc_unlocked -Wl,--wrap,_putc_r -Wl,--wrap,_putc_unlocked_r -Wl,--wrap,putchar -Wl,--wrap,putchar_unlocked -Wl,--wrap,_putchar_r -Wl,--wrap,_putchar_unlocked_r -Wl,--wrap,puts -Wl,--wrap,puts_unlocked -Wl,--wrap,_puts_r -Wl,--wrap,_puts_unlocked_r -Wl,--wrap,snprintf -Wl,--wrap,snprintf_unlocked -Wl,--wrap,_snprintf_r -Wl,--wrap,_snprintf_unlocked_r -Wl,--wrap,vsnprintf -Wl,--wrap,vsnprintf_unlocked -Wl,--wrap,_vsnprintf_r -Wl,--wrap,_vsnprintf_unlocked_r -Wl,--wrap,__assert -Wl,--wrap,__assert_unlocked -Wl,--wrap,___assert_r -Wl,--wrap,___assert_unlocked_r -Wl,--wrap,__assert_func -Wl,--wrap,__assert_func_unlocked -Wl,--wrap,___assert_func_r -Wl,--wrap,___assert_func_unlocked_r -Wl,--wrap,setbuf -Wl,--wrap,setbuf_unlocked -Wl,--wrap,_setbuf_r -Wl,--wrap,_setbuf_unlocked_r -Wl,--wrap,setvbuf -Wl,--wrap,setvbuf_unlocked -Wl,--wrap,_setvbuf_r -Wl,--wrap,_setvbuf_unlocked_r -Wl,--wrap,fprintf -Wl,--wrap,fprintf_unlocked -Wl,--wrap,_fprintf_r -Wl,--wrap,_fprintf_unlocked_r -Wl,--wrap,vfprintf -Wl,--wrap,vfprintf_unlocked -Wl,--wrap,_vfprintf_r -Wl,--wrap,_vfprintf_unlocked_r -Wl,--wrap,vprintf -Wl,--wrap,vprintf_unlocked -Wl,--wrap,_vprintf_r -Wl,--wrap,_vprintf_unlocked_r -Wl,--wrap,fputc -Wl,--wrap,fputc_unlocked -Wl,--wrap,_fputc_r -Wl,--wrap,_fputc_unlocked_r -Wl,--wrap,fputs -Wl,--wrap,fputs_unlocked -Wl,--wrap,_fputs_r -Wl,--wrap,_fputs_unlocked_r -Wl,--wrap,sprintf -Wl,--wrap,sprintf_unlocked -Wl,--wrap,_sprintf_r -Wl,--wrap,_sprintf_unlocked_r -Wl,--wrap,asprintf -Wl,--wrap,asprintf_unlocked -Wl,--wrap,_asprintf_r -Wl,--wrap,_asprintf_unlocked_r -Wl,--wrap,vasprintf -Wl,--wrap,vasprintf_unlocked -Wl,--wrap,_vasprintf_r -Wl,--wrap,_vasprintf_unlocked_r -Wl,--wrap,asiprintf -Wl,--wrap,asiprintf_unlocked -Wl,--wrap,_asiprintf_r -Wl,--wrap,_asiprintf_unlocked_r -Wl,--wrap,asniprintf -Wl,--wrap,asniprintf_unlocked -Wl,--wrap,_asniprintf_r -Wl,--wrap,_asniprintf_unlocked_r -Wl,--wrap,asnprintf -Wl,--wrap,asnprintf_unlocked -Wl,--wrap,_asnprintf_r -Wl,--wrap,_asnprintf_unlocked_r -Wl,--wrap,diprintf -Wl,--wrap,diprintf_unlocked -Wl,--wrap,_diprintf_r -Wl,--wrap,_diprintf_unlocked_r -Wl,--wrap,fiprintf -Wl,--wrap,fiprintf_unlocked -Wl,--wrap,_fiprintf_r -Wl,--wrap,_fiprintf_unlocked_r -Wl,--wrap,iprintf -Wl,--wrap,iprintf_unlocked -Wl,--wrap,_iprintf_r -Wl,--wrap,_iprintf_unlocked_r -Wl,--wrap,siprintf -Wl,--wrap,siprintf_unlocked -Wl,--wrap,_siprintf_r -Wl,--wrap,_siprintf_unlocked_r -Wl,--wrap,sniprintf -Wl,--wrap,sniprintf_unlocked -Wl,--wrap,_sniprintf_r -Wl,--wrap,_sniprintf_unlocked_r -Wl,--wrap,vasiprintf -Wl,--wrap,vasiprintf_unlocked -Wl,--wrap,_vasiprintf_r -Wl,--wrap,_vasiprintf_unlocked_r -Wl,--wrap,vasniprintf -Wl,--wrap,vasniprintf_unlocked -Wl,--wrap,_vasniprintf_r -Wl,--wrap,_vasniprintf_unlocked_r -Wl,--wrap,vasnprintf -Wl,--wrap,vasnprintf_unlocked -Wl,--wrap,_vasnprintf_r -Wl,--wrap,_vasnprintf_unlocked_r -Wl,--wrap,vdiprintf -Wl,--wrap,vdiprintf_unlocked -Wl,--wrap,_vdiprintf_r -Wl,--wrap,_vdiprintf_unlocked_r -Wl,--wrap,vfiprintf -Wl,--wrap,vfiprintf_unlocked -Wl,--wrap,_vfiprintf_r -Wl,--wrap,_vfiprintf_unlocked_r -Wl,--wrap,viprintf -Wl,--wrap,viprintf_unlocked -Wl,--wrap,_viprintf_r -Wl,--wrap,_viprintf_unlocked_r -Wl,--wrap,vsiprintf -Wl,--wrap,vsiprintf_unlocked -Wl,--wrap,_vsiprintf_r -Wl,--wrap,_vsiprintf_unlocked_r -Wl,--wrap,vsniprintf -Wl,--wrap,vsniprintf_unlocked -Wl,--wrap,_vsniprintf_r -Wl,--wrap,_vsniprintf_unlocked_r -specs=nano.specs -Wl,--gc-sections -Wl,--undefined=uxTopUsedPriority -Wl,--wrap,_malloc_r -Wl,--wrap,_free_r -Wl,--wrap,_calloc_r -Wl,--wrap,_realloc_r -n -Xlinker -Map=build/f7-firmware-C/.extapps/dolphin_jump_d.elf.map -Ttargets/f7/application_ext.ld -Ur -Wl,-Ur -nostartfiles -mlong-calls -fno-common -nostdlib -Wl,--no-export-dynamic -fvisibility=hidden -Wl,-edolphin_jump_app build/f7-firmware-C/.extapps/dolphin_jump/Game.o build/f7-firmware-C/.extapps/dolphin_jump/dolphin_jump.o build/f7-firmware-C/.extapps/dolphin_jump/main.o build/f7-firmware-C/.extapps/dolphin_jump/dolphin_jump_icons.o -Lbuild/f7-firmware-C/lib -lm -lgcc -lstdc++ -lsupc++
+arm-none-eabi-g++ @/var/folders/mj/qp601k_s0rx3cwsv6chm7_6h0000gn/T/tmp_yi0ce9y.lnk
+API version 69.0 is up to date
+prepare_app_metadata(["build/f7-firmware-C/.extapps/dolphin_jump.fap", "build/f7-firmware-C/.extapps/dolphin_jump/.fapmeta"], ["build/f7-firmware-C/.extapps/dolphin_jump_d.elf"])
+arm-none-eabi-objcopy --remove-section .ARM.attributes --add-section .fapmeta=build/f7-firmware-C/.extapps/dolphin_jump/.fapmeta --set-section-flags .fapmeta=contents,noload,readonly,data --strip-debug --strip-unneeded --add-gnu-debuglink=build/f7-firmware-C/.extapps/dolphin_jump_d.elf build/f7-firmware-C/.extapps/dolphin_jump_d.elf build/f7-firmware-C/.extapps/dolphin_jump.fap
+python3 scripts/fastfap.py build/f7-firmware-C/.extapps/dolphin_jump.fap arm-none-eabi-objcopy
+_validate_app_imports(["build/f7-firmware-C/.extapps/dolphin_jump.impsyms"], ["build/f7-firmware-C/.extapps/dolphin_jump.fap"])
+```
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03833-js---token-reading.md
+++ b/.ai/upstream-issues/03833-js---token-reading.md
@@ -1,0 +1,27 @@
+# Issue #3833: JS - Token reading
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3833](https://github.com/flipperdevices/flipperzero-firmware/issues/3833)
+**Author:** @Tomi2965
+**Created:** 2024-08-09T21:08:26Z
+**Labels:** Feature Request, JS
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+It's possible, to add a commands for JavaScript for reading/get tokens ID's? I mean, any. SubGHz, RFID, NFC, ... . 
+
+This function will help me and my colleagues to make  our work much & much faster.  In my case - use it to scan all new orders of tokens to system (NFC, RFID, iButton, for now, we are typing all ID's by hand, which cause mistakes from time to time). Then JS just send ID as a keyboard to PC. Of course, I will need to use JS to transform ID to different format. Manufacturer FDI write ID like 01AB34CD, but Flipper read it as CD34AB01. 
+
+Of course, I was try to search for possible commands in Flipper's JS, if these functions are implemented, then please sorry (send me a link). If not, it's possible to make a solution? Flipper with JS but without ability to return token ID is just a waste of anything. But.. If Flipper can do this, it will make Flipper more customizable and usable.
+
+Please, leave any comments, ask any questions. 
+
+PS: big thanks to anyone, who constructively helps to make Flipper better ♥️ 
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03835-attempting-to-read-desfire-card-causes-furi_check.md
+++ b/.ai/upstream-issues/03835-attempting-to-read-desfire-card-causes-furi_check.md
@@ -1,0 +1,72 @@
+# Issue #3835: Attempting to read DESFire Card causes `furi_check()` crash
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3835](https://github.com/flipperdevices/flipperzero-firmware/issues/3835)
+**Author:** @5aji
+**Created:** 2024-08-11T17:08:30Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+Reading a DESFire card crashes the Flipper with a `furi_check()` error. It seems to crash after trying to read the second block. This is a card I had lying around, and I do not possess the keys (nor am I trying to get them). This happens on both 0.104.0 and 0.105.0-RC.
+
+### Reproduction
+
+1. Open NFC App -> Read
+2. Alternatively, select Extra-> Read Specific -> DESFire
+3. Touch Flipper to keycard
+4. Lights blink for a split second and then the system reboots.
+
+### Target
+
+Mifare DESFire Card
+
+### Logs
+
+```Text
+1050914 [D][NfcSupportedCards] Loaded 19 plugins
+1050929 [D][Iso14443_4aPoller] Read ATS success
+1050938 [D][MfDesfirePoller] Read version success
+1050942 [D][MfDesfirePoller] Read free memory success
+1050946 [D][MfDesfirePoller] Read master key settings success
+1050950 [D][MfDesfirePoller] Read master key version success
+1050955 [D][MfDesfirePoller] Read application ids success
+1050958 [D][MfDesfirePoller] Selecting app 0
+1050963 [D][MfDesfirePoller] Reading app 0
+1050974 [D][MfDesfirePoller] Can't read file 0 data without authentication
+1050978 [D][MfDesfirePoller] Selecting app 1
+1050983 [D][MfDesfirePoller] Reading app 1
+1050999 [D][MfDesfirePoller] Can't read file 1 data without authentication
+1051002 [D][MfDesfirePoller] Selecting app 2
+1051007 [D][MfDesfirePoller] Reading app 2
+
+[CRASH][NfcWorker] furi_check failed
+        r0 : 20025fe8
+        r1 : 200251d0
+        r2 : 0
+        r3 : 0
+        r4 : 0
+        r5 : 0
+        r6 : 20025fe8
+        r7 : 200251d0
+        r8 : 80a22e7
+        r9 : 80a23d6
+        r10 : 80a23e8
+        r11 : 20031364
+        lr : 80389d9
+        stack watermark: 7556
+             heap total: 186064
+              heap free: 31576
+         heap watermark: 27568
+        core2: not faulted
+Rebooting system�0
+```
+
+
+### Anything else?
+
+I have a Proxmark3 if that would help provide more information. 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03848-mifare-classic-1k-ev1-is-recognized-as-1k-16-sect.md
+++ b/.ai/upstream-issues/03848-mifare-classic-1k-ev1-is-recognized-as-1k-16-sect.md
@@ -1,0 +1,66 @@
+# Issue #3848: MIFARE Classic 1K EV1 is recognized as 1K, 16 sectors/32 keys
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3848](https://github.com/flipperdevices/flipperzero-firmware/issues/3848)
+**Author:** @noproto
+**Created:** 2024-08-20T00:09:12Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+I have a MIFARE Classic 1K EV1 tag which I read with the Flipper and received this result:
+
+![image](https://github.com/user-attachments/assets/9ca109cc-5fa4-421d-a381-bfce264d8b65)
+
+Reading the same tag with the Proxmark results in:
+
+```
+[usb] pm3 --> hf mf autopwn
+[=] MIFARE Classic EV1 card detected
+(..)
+[+] -----+-----+--------------+---+--------------+----
+[+]  Sec | Blk | key A        |res| key B        |res
+[+] -----+-----+--------------+---+--------------+----
+[+]  000 | 003 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  001 | 007 | 8A19D40CF2B5 | H | 8A19D40CF2B5 | R
+[+]  002 | 011 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  003 | 015 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  004 | 019 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  005 | 023 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  006 | 027 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  007 | 031 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  008 | 035 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  009 | 039 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  010 | 043 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  011 | 047 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  012 | 051 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  013 | 055 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  014 | 059 | FFFFFFFFFFFF | D | FFFFFFFFFFFF | D
+[+]  015 | 063 | 8A19D40CF2B5 | R | 8A19D40CF2B5 | R
+[+]  016 | 067 | 5C8FF9990DA2 | D | D01AFEEB890A | D ( * )
+[+]  017 | 071 | 75CCB59C9BED | D | 4B791BEA7BCC | D ( * )
+[+] -----+-----+--------------+---+--------------+----
+[=] ( * ) These sectors used for signature. Lays outside of user memory
+```
+
+Because `sectors_total` is miscalculated, this is interfering with the dictionary attack (which is not attempting to read the two signature sectors or discover these keys) and further may cause the card to fail emulation at a legitimate reader.
+
+### Reproduction
+
+Using an EV1 1K tag, read with official NFC app. Note 16 sectors and 32 keys tested.
+
+### Target
+
+12.F7B9C6 R02, OFW 0.105.0
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03853-reading-an-emulated-amiibo-causes-flipper-zero-to-.md
+++ b/.ai/upstream-issues/03853-reading-an-emulated-amiibo-causes-flipper-zero-to-.md
@@ -1,0 +1,31 @@
+# Issue #3853: Reading an emulated Amiibo causes Flipper Zero to crash using NFC read but works using NFC Read specific card type
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3853](https://github.com/flipperdevices/flipperzero-firmware/issues/3853)
+**Author:** @ukscone
+**Created:** 2024-08-24T16:28:49Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the bug.
+
+When trying to read an emulated Amiibo from a device like the Flashiibo (https://www.flashiibo.com/) or Maleen NFC Tag Generator that uses an nRF52832 to emulate NTAG N215 tags the Flipper zero crashes and reboots with a furi_check failed error & the last line in the logs in debug or trace mode is "[D][NfcScanner] Found 5 children" when using the NFC Read but when using NFC->Extra Actions->Read Specific Card Type as either iso14443-3a or NTAG it works as expected.
+
+### Reproduction
+
+Apps->NFC->NFC->Read then hold a multi-ntag emulator device to the back of the flipper and watch the flipper screen darken and then "reboot" with a flipper crashed and was rebooted furi_check failed message 
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03867-flipper-misidentifies-visonic_powecode-alarm-signa.md
+++ b/.ai/upstream-issues/03867-flipper-misidentifies-visonic_powecode-alarm-signa.md
@@ -1,0 +1,38 @@
+# Issue #3867: Flipper misidentifies Visonic_Powecode alarm signal as Dickert_MAHS.
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3867](https://github.com/flipperdevices/flipperzero-firmware/issues/3867)
+**Author:** @Hamika20
+**Created:** 2024-09-02T20:01:00Z
+**Labels:** Sub-GHz, Bug
+
+## Description
+
+### Describe the bug.
+
+I think I've found a bug with this new protocol called Dickert_MAHS. I receive this signal multiple times a day, even though I live in a rural area far away from other garages. I receive the signal about 30 times a day. Even at midnight. When I use RTL433, the signal appears as a Visonic-Powercode sensor. I'm not sure if the Flipper is misidentifying the sensor's signal or if something else is happening.
+
+
+![Screenshot-20240902-223327dd](https://github.com/user-attachments/assets/8242ceba-bacf-40c4-afee-04430dabd900)
+![Screenshot-20240902-222130flip](https://github.com/user-attachments/assets/4492a432-f5c2-41fb-94c2-ae673733ec10)
+![Screenshot_2024-08-28_174412](https://github.com/user-attachments/assets/8de0ba56-6f9d-49fe-baef-4300b609857d)
+
+
+### Reproduction
+
+I copied the signal from the remote and tried replaying it, but RTL433 didn't recognize it at all.
+I think I will need to further investigate and try to find a similar motion detector and trigger it manually.
+
+### Target
+
+Devs
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03870-rfid-not-detecting-some-card-types-that-other-devi.md
+++ b/.ai/upstream-issues/03870-rfid-not-detecting-some-card-types-that-other-devi.md
@@ -1,0 +1,36 @@
+# Issue #3870: RFID not detecting some card types that other devices detect (e.g. Keysy) 
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3870](https://github.com/flipperdevices/flipperzero-firmware/issues/3870)
+**Author:** @PsiPhiTheta
+**Created:** 2024-09-03T11:41:45Z
+**Labels:** RFID 125kHz, Bug
+
+## Description
+
+### Describe the bug.
+
+F0 is refusing to read some RFID cards (but working on others). I see a lot of posts about RFID functionality on the flipper being rather temperamental. I used to use the Keysy RFID cloner which works absolutely fine for everything I throw at it but I see some protocols seem to not have been programmed on flipper? Is that right? I will attach the raw reads to this issue for your reference. I also tried many times, completely still on a table, free from interference etc. 
+
+### Reproduction
+
+1. Switch on
+2. Press RFID
+3. Reading ASK / PSK scans continually without detecting anything 
+[413psk.txt](https://github.com/user-attachments/files/16848016/413psk.txt)
+[413ask.txt](https://github.com/user-attachments/files/16848017/413ask.txt)
+
+
+### Target
+
+Keysy rewritable key fob
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03876-mouse-clicker-should-have-a-0-value-setting-for-.md
+++ b/.ai/upstream-issues/03876-mouse-clicker-should-have-a-0-value-setting-for-.md
@@ -1,0 +1,23 @@
+# Issue #3876: Mouse Clicker Should have a "0" value setting for "as fast as possible"
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3876](https://github.com/flipperdevices/flipperzero-firmware/issues/3876)
+**Author:** @austeregrim
+**Created:** 2024-09-05T16:29:31Z
+**Labels:** Feature Request, USB, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Asking for a feature where the HID Bluetooth Mouse Clicker would have a minimum value setting of "0" to enable a no-wait click, or the most minimal wait (ie. 1ms) if a true no-wait loop would cause the flipper to logically freeze.
+
+applications/system/hid_app/views/hid_mouse_clicker.c
+
+thanks...  I might look at handling this request myself, but I'm not comfortable yet.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03877-less-granular-value-selection-in-bluetooth-hid-mou.md
+++ b/.ai/upstream-issues/03877-less-granular-value-selection-in-bluetooth-hid-mou.md
@@ -1,0 +1,27 @@
+# Issue #3877: Less granular value selection in Bluetooth HID Mouse Clicker
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3877](https://github.com/flipperdevices/flipperzero-firmware/issues/3877)
+**Author:** @austeregrim
+**Created:** 2024-09-05T16:37:14Z
+**Labels:** Feature Request, USB, Applications
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+- Current:
+The mouse clicker cps value selection goes from 1 to 60 in 1cps increments
+
+- Issue:
+not sure if there is real value for the granular selection change of 1cps increment.  (I understand this is probably more of an example app)
+
+- Change:
+Where the value selection could go 1 to 5 to 10 to 15, etc... 
+Or maybe 1, 2, 4, 8, 16, 32, 64?
+
+### Anything else?
+
+thank you
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03883-blackmagic--warning-upon-attaching-to-flipper-fw.md
+++ b/.ai/upstream-issues/03883-blackmagic--warning-upon-attaching-to-flipper-fw.md
@@ -1,0 +1,66 @@
+# Issue #3883: Blackmagic: Warning upon attaching to Flipper FW
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3883](https://github.com/flipperdevices/flipperzero-firmware/issues/3883)
+**Author:** @CookiePLMonster
+**Created:** 2024-09-07T16:38:05Z
+**Labels:** Build System & Scripts, Triage
+
+## Description
+
+### Describe the bug.
+
+`warning: could not convert 'FlipperApplication' from the host encoding (CP1252) to UTF-32. This normally should not happen, please file a bug report.` warning appears in the debug console upon attaching Blackmagic. This doesn't appear to have any side effects, but might be worth checking out regardless.
+
+### Reproduction
+
+1. Set up uFBT on a Windows machine with a Windows-1252 (Central Europe) codepage.
+2. In VSCode, use `Attach FW (blackmagic).
+3. Observe the warning.
+
+### Target
+
+f7 running stable v0.105.0 + devboard in blackmagic mode, running the latest dev FW (the one that adds UART over web)
+
+### Logs
+
+```Text
+Cortex-Debug: VSCode debugger extension version 1.12.1 git(652d042). Usage info: https://github.com/Marus/cortex-debug#usage
+Reading symbols from H:/dev/flipper-zero/.ufbt/toolchain/x86_64-windows/bin/arm-none-eabi-objdump.exe --syms -C -h -w H:/dev/flipper-zero/.ufbt/current/firmware.elf
+Reading symbols from h:/dev/flipper-zero/.ufbt/toolchain/x86_64-windows/bin/arm-none-eabi-nm.exe --defined-only -S -l -C -p H:/dev/flipper-zero/.ufbt/current/firmware.elf
+Launching GDB: "H:/dev/flipper-zero/.ufbt/toolchain/x86_64-windows/bin/arm-none-eabi-gdb-py3.EXE" -q --interpreter=mi2
+    IMPORTANT: Set "showDevDebugOutput": "raw" in "launch.json" to see verbose GDB transactions here. Very helpful to debug issues or report problems
+Finished reading symbols from objdump: Time: 80 ms
+Output radix now set to decimal 16, hex 10, octal 20.
+Input radix now set to decimal 10, hex a, octal 12.
+Cortex-M timeout to wait for device halts: 2000
+Available Targets:
+No. Att Driver
+ 1      STM32WBxx (secure) M4
+Attaching to program: H:\dev\flipper-zero\.ufbt\current\firmware.elf, Remote target
+Finished reading symbols from nm: Time: 691 ms
+vPortSuppressTicksAndSleep (expected_idle_ticks=0xa1) at targets/f7/furi_hal/furi_hal_os.c:172
+172	targets/f7/furi_hal/furi_hal_os.c: No such file or directory.
+Program stopped, probably due to a reset and/or halt issued by debugger
+Firmware version on attached Flipper:
+	Version:     0.105.0
+	Built on:    15-08-2024
+	Git branch:  0.105.0
+	Git commit:  8ea6a3df
+	Dirty:       False
+	HW Target:   7
+	Origin:      Official
+	Git origin:  https://github.com/flipperdevices/flipperzero-firmware
+Support for Flipper external apps debug is loaded
+Set 'H:/dev/flipper-zero/.ufbt/build' as debug info lookup path for Flipper external apps
+Attaching to Flipper firmware
+warning: could not convert 'FlipperApplication' from the host encoding (CP1252) to UTF-32.
+This normally should not happen, please file a bug report.
+```
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03884-blackmagic--reset-reset-device-dont-work-if-execu.md
+++ b/.ai/upstream-issues/03884-blackmagic--reset-reset-device-dont-work-if-execu.md
@@ -1,0 +1,52 @@
+# Issue #3884: Blackmagic: Reset/Reset Device don't work if execution is suspended on `furi_check()`
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3884](https://github.com/flipperdevices/flipperzero-firmware/issues/3884)
+**Author:** @CookiePLMonster
+**Created:** 2024-09-07T16:41:54Z
+**Labels:** Build System & Scripts, Triage
+
+## Description
+
+### Describe the bug.
+
+When debugging with Blackmagic (in my case, through WiFi), if the Flipper suspends on `furi_check` it appears to be impossible to reboot it. Neither Reset Device or Reset commands do anything, so the device has to be disconnected from USB and then power cycled by holding Back for 30s.
+
+### Reproduction
+
+1. Attach Blackmagic to FW when Flipper is connected to the PC via the USB cable (in practice, necessary for FAP development).
+2. Make it crash on `furi_check()`.
+3. Attempt to reset the device via a debugger.
+4. Observe errors in log
+
+### Target
+
+f7 running stable v0.105.0 + devboard in blackmagic mode, running the latest dev FW (the one that adds UART over web)
+
+### Logs
+
+```Text
+Waiting for gdb server to start...[2024-09-04T10:21:17.225Z] SERVER CONSOLE DEBUG: onBackendConnect: gdb-server session connected. You can switch to "DEBUG CONSOLE" to see GDB interactions.
+"H:/dev/flipper-zero/.ufbt/toolchain/x86_64-windows/bin/openocd.EXE" -c "gdb_port 50000" -c "tcl_port 50001" -c "telnet_port 50002" -s "H:\\dev\\flipper-zero\\flipper-bakery\\digital_clock" -f "c:/Users/Adrian/.vscode/extensions/marus25.cortex-debug-1.12.1/support/openocd-helpers.tcl" -f interface/cmsis-dap.cfg -f "H:/dev/flipper-zero/.ufbt/current/scripts/debug/stm32wbx.cfg" -c "CDRTOSConfigure FreeRTOS"
+Open On-Chip Debugger 0.12.0+dev-g708504d4b (2024-07-18-12:29)
+Licensed under GNU GPL v2
+For bug reports, read
+        http://openocd.org/doc/doxygen/bugs.html
+CDLiveWatchSetup
+Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
+Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
+Info : Listening on port 50001 for tcl connections
+Info : Listening on port 50002 for telnet connections
+c:/Users/Adrian/.vscode/extensions/marus25.cortex-debug-1.12.1/support/openocd-helpers.tcl: stm32wbx.cpu configure -rtos FreeRTOS
+Error: unable to find a matching CMSIS-DAP device
+
+[2024-09-04T10:21:17.386Z] SERVER CONSOLE DEBUG: onBackendConnect: gdb-server session closed
+GDB server session ended. This terminal will be reused, waiting for next session to start...
+```
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03898-universal-remote-feature---enhancement-request.md
+++ b/.ai/upstream-issues/03898-universal-remote-feature---enhancement-request.md
@@ -1,0 +1,20 @@
+# Issue #3898: Universal Remote Feature - Enhancement Request
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3898](https://github.com/flipperdevices/flipperzero-firmware/issues/3898)
+**Author:** @HeIp
+**Created:** 2024-09-14T13:54:03Z
+**Labels:** Feature Request, Infrared
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Currently flipper zero(Universal Remote Feature) sends a bunch of standardized codes for power on, power off, volume up/down etc....
+I think for those who have lost their remotes, it would be easier to save and replay previous signals instead of having to redo the whole process to be able to replay the signals that work with their device.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03907-nfc-read-does-not-identify-mf-ultralight-card---of.md
+++ b/.ai/upstream-issues/03907-nfc-read-does-not-identify-mf-ultralight-card---of.md
@@ -1,0 +1,31 @@
+# Issue #3907: NFC Read does not identify MF Ultralight card - OFW 1.01
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3907](https://github.com/flipperdevices/flipperzero-firmware/issues/3907)
+**Author:** @kwjw3d
+**Created:** 2024-09-17T22:57:59Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the bug.
+
+When reading an Ultralight NFC card, it only identifies the card as ISO14443-3A (Unknown) when previously it would identify this type of card correctly.
+
+### Reproduction
+
+Read NFC card, see Unknown instead of Ultralight
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03910-mbedtls.cfg.h-is-not-accessible-when-using-local.md
+++ b/.ai/upstream-issues/03910-mbedtls.cfg.h-is-not-accessible-when-using-local.md
@@ -1,0 +1,50 @@
+# Issue #3910: `mbedtls.cfg.h` is not accessible when using local SDKs via uFBT
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3910](https://github.com/flipperdevices/flipperzero-firmware/issues/3910)
+**Author:** @CookiePLMonster
+**Created:** 2024-09-18T18:35:01Z
+**Labels:** Bug, Build System & Scripts
+
+## Description
+
+### Describe the bug.
+
+Attempting to use a self-built SDK with uFBT via `ufbt update --local=X` seems to be unable to detect `mbedtls.cfg.h`, even though it is bundled in the `.zip` update package:
+
+```
+In file included from H:/dev/flipper-zero/.ufbt/current/sdk_headers/f7_sdk/lib/mbedtls/include/mbedtls/bignum.h:14,
+                 from H:\dev\flipper-zero\flipper-bakery\flipper95\flipper95.c:14:
+H:/dev/flipper-zero/.ufbt/current/sdk_headers/f7_sdk/lib/mbedtls/include/mbedtls/build_info.h:79:10: error: #include expects "FILENAME" or <FILENAME>
+   79 | #include MBEDTLS_CONFIG_FILE
+      |          ^~~~~~~~~~~~~~~~~~~
+```
+
+Am I maybe missing a step in my local SDK builds and I need more than just `./fbt updater_package`?
+
+### Reproduction
+
+I'll outline the steps using my own app, but it's unlikely to be isolated to just that.
+
+1. Have a local debug SDK build done from FBT, in my case build with `./fbt updater_package`.
+2. Switch uFBT to use this local SDK - `ufbt update --local=h:\dev\flipper-zero\flipperzero-firmware\dist\f7-D\flipper-z-f7-sdk-local.zip --hw-target=f7`
+3. Clone [Flipper95](https://github.com/CookiePLMonster/flipper-bakery/tree/flipper-alarm/flipper95) and set up `ufbt vscode_dist` on it.
+4. Attempt to build the app with `ufbt`.
+5. Observe a `sdk_headers/f7_sdk/lib/mbedtls/include/mbedtls/build_info.h:79:10: error: #include expects "FILENAME" or <FILENAME>` error.
+6. Switch uFBT to the latest dev or release track via `ufbt update --channel=release/dev`.
+7. Attempt to build the app again.
+8. Observe the errror **does not occur**.
+
+### Target
+
+f7 with latest dev release
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03911-nfc-emulation-not-working-since-0.94.1.md
+++ b/.ai/upstream-issues/03911-nfc-emulation-not-working-since-0.94.1.md
@@ -1,0 +1,33 @@
+# Issue #3911: NFC Emulation Not Working Since 0.94.1
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3911](https://github.com/flipperdevices/flipperzero-firmware/issues/3911)
+**Author:** @S4RP1NG0
+**Created:** 2024-09-19T11:31:20Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+Hello. NFC emulation has not been working since version 0.94.1. I updated to the latest versions, formatted it many times, tried software such as unleashed, Xtreme, RogueMaster but the result did not change. My NFC card that I use for the apartment only works in version 0.94.1.
+
+I reintroduce the card, it registers the card without giving any errors but it does not emulate. Does anyone have any ideas?
+
+### Reproduction
+
+NFC Emulation not working since 0.94.1
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03913-consider-enabling-c23-and-c23.md
+++ b/.ai/upstream-issues/03913-consider-enabling-c23-and-c23.md
@@ -1,0 +1,27 @@
+# Issue #3913: Consider enabling C++23 and C23
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3913](https://github.com/flipperdevices/flipperzero-firmware/issues/3913)
+**Author:** @CookiePLMonster
+**Created:** 2024-09-20T10:42:53Z
+**Labels:** Feature Request, Build System & Scripts
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Currently, the C and C++ standard seems to be defined as follows:
+* FBT - `-std=gnu2x` for C, `-std=c++20` for C++
+* uFBT - nothing? for C, `-std=c++20` for C++
+* vscode config - `gnu23` for C, `c++20` for C++
+
+Since GCC has partial support for C++23 since GCC11, please consider the following:
+1. Enable `gnu23` for C in FBT and uFBT, or `gnu2x` if GCC 12 doesn't support `gnu23` yet.
+2. Enable `gnu++2b` for C++ in FBT and uFBT. This gives us access to most C++23 features with GNU extensions. Or, if you don't want the GNU extensions, `c++2b` will do too.
+3. Enable `gnu++23` in the vscode config, or `c++23` if you don't want the GNU extensions.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03938-sub-ghz-request-support-for-sherlotronics-403.55.md
+++ b/.ai/upstream-issues/03938-sub-ghz-request-support-for-sherlotronics-403.55.md
@@ -1,0 +1,50 @@
+# Issue #3938: [Sub-Ghz] Request support for Sherlotronics 403.55Mhz Transmitter
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3938](https://github.com/flipperdevices/flipperzero-firmware/issues/3938)
+**Author:** @Axolotl5903
+**Created:** 2024-10-11T17:22:47Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Sherlotronics TX-6 (6 Button) 403MHz key fob
+
+1. Frequency: 403.55 MHz
+2. Modulation: ASK / OOK (Unsure is AM270 / AM650)
+3. Dynamic Code (KeeLoq Code-Hopping)
+4. RAW Signal Dumps for 3 remotes 
+
+The Flipper Zero is able to detect that the transmitter uses KeeLoq 64 Bit Protocol, as well as the transmitted keys, Hopper code, Button number, and the transmitter's fixed code.
+[Sherlotronics Sample1 RAW.sub.txt](https://github.com/user-attachments/files/17345754/Sherlotronics.Sample1.RAW.sub.txt)
+[Sherlotronics Sample2 RAW.sub.txt](https://github.com/user-attachments/files/17345755/Sherlotronics.Sample2.RAW.sub.txt)
+[Sherlotronics Sample3 RAW.sub.txt](https://github.com/user-attachments/files/17345757/Sherlotronics.Sample3.RAW.sub.txt)
+
+### Anything else?
+
+Hi,
+I have a bunch of Sherlotronics TX-6 (6 Button) 403MHz key fobs that I use with Sherlotronics RX1-150 receivers, that I connected to my Garage openers, and would really appreciate it if support for their protocol could be added.
+
+I've verified that the transmitter (remotes) utilizes the HCS301 Chip
+I also have a older model of the TX-6 Transmitter (Blue PCB) that I found is also compatible with newer Sherlotronics receivers. I descovered that Sherlotronics did a refresh on all their 2015 transmitters and receivers in 2017, changing from Blue to Green PCB's, and the HSC301 Chip SN Number changed from SN1541 ET4 to SN2117 ET7. 
+
+I also noticed that both PCB's have these 4 contact points on the right side of the PCB, that has the word "PROGRAM" printed next to it, I'm unsure what it's for, but my guess is that there might be a way to program the transmitter.
+
+Sherlotronics is a Local South African Manufacturer, thus their transmitters aren't required to have FCC ID's. However, it does have the following certifications: 
+- EN300-220 Nov 1997
+- SABS ETSI EN301-489-1:2001
+- SABS IEC 60950:1999
+- ICASA: TA-2006/759
+
+Any attempt of adding support for this transmitter's protocol would be greatly appreciated, please feel free to contact me if any additional information is required, here is a link to Sherlotronic's official website: https://www.sherlotronics.co.za
+I will also attach PDF documents containing additional information of the transmitters and receivers:
+https://www.sherlotronics.co.za/wp-content/uploads/2020/09/Sherlo-Keyring-Remote-Control-Sales-Leaflet.pdf
+https://www.sherlotronics.co.za/wp-content/uploads/2018/04/TX1_2_4_6_Installation.pdf
+https://www.sherlotronics.co.za/wp-content/uploads/2018/04/TX1_2_4_6_ICASA-Certificate.pdf
+https://www.sherlotronics.co.za/wp-content/uploads/2018/04/TX1_2_4_6_Product-Declaration.pdf
+
+Thank you!
+
+P.S. I attached the raw subghz files with the extension ".txt" as Github doesn't support .sub files.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03939-readkeystate-function-for-badusb-mjs-module.md
+++ b/.ai/upstream-issues/03939-readkeystate-function-for-badusb-mjs-module.md
@@ -1,0 +1,21 @@
+# Issue #3939: readKeyState function for badusb mjs module
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3939](https://github.com/flipperdevices/flipperzero-firmware/issues/3939)
+**Author:** @mantacid
+**Created:** 2024-10-11T18:13:16Z
+**Labels:** Feature Request, JS
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+The firmware of most external keyboards allows the keyboard to receive signals from the device to which it is connected, in order to update the status LEDs for the caps-lock, num-lock, and scroll-lock keys. This could be a useful method of data exfiltration in airgapped systems: if the flipper zero could read the state of a virtual keyboard, a badusb payload could install and execute a script on the target machine that uses these keys to send data directly to the flipper itself.
+
+The feature could take the form of a `readKeyState()` method in the JavaScript `badusb` module, or even a separate method for each key.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03981-show-alarm-icon-in-status-bar-if-alarm-set.md
+++ b/.ai/upstream-issues/03981-show-alarm-icon-in-status-bar-if-alarm-set.md
@@ -1,0 +1,19 @@
+# Issue #3981: Show alarm icon in status bar if alarm set
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3981](https://github.com/flipperdevices/flipperzero-firmware/issues/3981)
+**Author:** @j-lakeman
+**Created:** 2024-11-01T13:03:47Z
+**Labels:** New Feature, Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Appreciate the possibility to set an alarm in the latest RC. Would be nice if an optional icon could be set to be shown in the status bar.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03984-rfid-read-problem.md
+++ b/.ai/upstream-issues/03984-rfid-read-problem.md
@@ -1,0 +1,26 @@
+# Issue #3984: RFID Read problem
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3984](https://github.com/flipperdevices/flipperzero-firmware/issues/3984)
+**Author:** @vilmar-hillow
+**Created:** 2024-11-02T22:02:20Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Description of the feature you're suggesting.
+
+RFID fob that looks like this:
+
+![fob](https://github.com/user-attachments/assets/1634d7c5-e0a3-4d8a-82c0-270a30c9b50a)
+
+Here's raw ask/psk:
+[fob.zip](https://github.com/user-attachments/files/17608494/fob.zip)
+
+The reader manufacturer is Verex, fob might be g-prox? Emulating raw signal works
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/03994-clock--alarm---lot-of-improvements-needed.md
+++ b/.ai/upstream-issues/03994-clock--alarm---lot-of-improvements-needed.md
@@ -1,0 +1,45 @@
+# Issue #3994: Clock & Alarm - lot of improvements needed
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/3994](https://github.com/flipperdevices/flipperzero-firmware/issues/3994)
+**Author:** @Tomi2965
+**Created:** 2024-11-08T16:39:21Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Today I was must leave my FZ at home (for 10 hours). After I come home, I hear my FZ beeping (alarm set to 07:00, I was return at 17:02). Alarm need these improvements and features:
+
+1.) when user not dismiss alarm after X minutes, set repeat alarm after X minutes, do not beep & vibrate fulltime. Today my FZ run alarm for 10 hours constantly, and drained more than 40% of battery.
+
+2.) when alarm is set, run alarm on phone too (app). Or add function to synchronize phone alarms with FZ?
+
+3.) on locked FZ I see active animation, not a reason of beeping - need to show alarm screen when FZ is locked + there was visible icon of active app, not an alarm icon (maybe irrelevant)
+
+4.) on alarmscreen is actual time, but not visible time of alarm set (important for snooze function)
+
+5.) you cannot dismiss alarm on lockscreen by any way, only by restart or unlock - may be annoying for unexperienced pplz (like my parents for example). 
+
+6.) snooze function is missing at all (for example default for 5 mins)
+
+7.) cannot set, dismiss, snooze or set alarm easily via app
+
+8.) no visible information about future (current set) alarm in app
+
+9.) there are no instructions on alarmscreen - for future - right/left/up/down/center = snooze, back = dismiss alarm
+
+10.) possible to add more/custom melodies? 
+
+11.) lockscreen - enter password, it's annoying that display flashes until a password is entered. Same situation when app is opened via app. There is no info about active alarm on remote control. App is working, but FZ is flashing, vibrating, beeping.
+
+12.) settings - C&A - alarm - currently u can set on/off, add one time function
+
+
+
+### Anything else?
+
+Thanks for any improvements. Have a nice day.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04002-rfe--cannot-write-nfc-v-tag.md
+++ b/.ai/upstream-issues/04002-rfe--cannot-write-nfc-v-tag.md
@@ -1,0 +1,54 @@
+# Issue #4002: RFE: Cannot write NFC-V tag
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4002](https://github.com/flipperdevices/flipperzero-firmware/issues/4002)
+**Author:** @marcmerlin
+**Created:** 2024-11-13T21:49:27Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+### Describe the bug.
+
+I'm using the latest available firmware as of today. I have an NFC-V tag on a water filter that I'd like to duplicate to a blank tag, but copying is not offered for this type of tag, only emulation and that emulation didn't seem to work (my water filter didn't see the emulated tag at all, or didn't like it).
+
+Old versions of flipper zero recognized the tag as ISO15693-3 (unknown)
+![image](https://github.com/user-attachments/assets/02741137-2f9d-42f5-803d-099958148f6f)
+
+New (today's) firmware, recognizes the tag as SLIX
+![image](https://github.com/user-attachments/assets/e6f7d000-561b-4be0-b5b5-f76c540349fc)
+
+For comparison, the same tag seen by android
+![image](https://github.com/user-attachments/assets/eac680fe-b5ba-48d3-b71f-4b94e9551ede)
+
+### Reproduction
+
+Reading the tag works, emulating it seems to work, but at least in my case does not. I can't tell if the emulation is bad or if I have another issue.
+But more importantly, there is no 'copy' option that I can find.
+
+I bought these 2 kinds of tags, but currently cannot write to them:
+https://www.amazon.com/dp/B0755WF6CK
+
+Any idea what I'm doing wrong, or not supported yet?
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+### Anything else?
+
+I may have filed this in the wrong repo originally, namely https://github.com/DarkFlippers/unleashed-firmware/issues/836
+apologies for that.
+I'm happy to close the other one if appropriate
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04007-universal-ir.md
+++ b/.ai/upstream-issues/04007-universal-ir.md
@@ -1,0 +1,19 @@
+# Issue #4007: universal IR
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4007](https://github.com/flipperdevices/flipperzero-firmware/issues/4007)
+**Author:** @ddddddddggfekzurkj
+**Created:** 2024-11-18T17:12:29Z
+**Labels:** Feature Request, Infrared
+
+## Description
+
+### Description of the feature you're suggesting.
+
+add to the universal IR remote control the ability to pause, scroll to the previous or next signal, save it and send the desired signal, like in the sub-ghz bruteforcer application
+
+### Anything else?
+
+добавте в универсальный ик пульт возможность приостановить, перелистнуть на прошлый или следующий сигнал, сохранить его и  отправить нужный сигнал типо как в приложении sub-ghz bruteforcer 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04011-change-bluetooth---device-name.md
+++ b/.ai/upstream-issues/04011-change-bluetooth---device-name.md
@@ -1,0 +1,19 @@
+# Issue #4011: change Bluetooth / device name
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4011](https://github.com/flipperdevices/flipperzero-firmware/issues/4011)
+**Author:** @j-lakeman
+**Created:** 2024-11-21T18:18:44Z
+**Labels:** Feature Request, Bluetooth
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Would be awesome if the Bluetooth name advertised by the Flipper could be changed. That would also increase privacy (see #2031)
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04012-flipper-zero-mifare-plus-2k-support-sl1-only.md
+++ b/.ai/upstream-issues/04012-flipper-zero-mifare-plus-2k-support-sl1-only.md
@@ -1,0 +1,19 @@
+# Issue #4012: Flipper Zero Mifare Plus 2K support (SL1 ONLY)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4012](https://github.com/flipperdevices/flipperzero-firmware/issues/4012)
+**Author:** @Overc1ocker
+**Created:** 2024-11-22T10:18:45Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I know flipper has supported Mifare Classic 1K systems for awhile. This is mostly due to the insecure CRYPTO1 algorithm being used to secure the card. However, it seems that Mifare Plus systems are now slowly being used in place of Classic 1k and these are supposed to be encrypted with 128bit AES encryption. However, there is a catch. SL1 Mifare Plus systems are still using the insecure Crypto1 standard and currently Flipper zeros can read/ decrypt these SL1 cards in full by telling the Flipper they are actually Classic 1K (you may need to grab the keys using "detect reader"). The only problem with this is when doing some research online, I learned that certain SL1 cards make use of 2 additional partitions (16 and 17) and it doesn't seem as though the flipper can read these yet. Is it possible to add the extras in the future for experimentation purposes?
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04016-badusb-f13-f24-keys-support-not-functional.md
+++ b/.ai/upstream-issues/04016-badusb-f13-f24-keys-support-not-functional.md
@@ -1,0 +1,41 @@
+# Issue #4016: BadUSB F13-F24 keys support not functional
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4016](https://github.com/flipperdevices/flipperzero-firmware/issues/4016)
+**Author:** @jezh42
+**Created:** 2024-11-25T03:41:48Z
+**Labels:** Feature Request, USB
+
+## Description
+
+### Describe the bug.
+
+When trying to use BadUsb and badusb-js on the latest version of the firmware, I am unable to properly emulate the F13-F24 keys. Support for these keys were apparently added back in [March](https://github.com/flipperdevices/flipperzero-firmware/pull/3468), and the code has not been removed since. 
+When executing a BadUsb script with F1->F24 connected to a Windows or Linux machine, with a supported keyboard input program monitoring keypresses, I am unable to register any of the F13-F24 keys.
+Using other software, such as AutoHotKey, I am able to register F13-F24, so the monitoring program is not the issue. Furthermore, Windows has support for F13-F24 shortcuts, such as the default enabled Win + F21 opening settings, which I am also unable to emulate through Flipper BadUsb.
+I have tried using badusb-js as well, trying F13-F24 directly, HID decimal and HID hex and no success.
+
+
+
+### Reproduction
+
+1. Create a BadUsb script containing F13 up to F24, each on new lines, followed by "GUI F21" on the final line
+2. Copy script to Flipper
+3. Plug Flipper into a Windows computer via USB
+4. Open a keyboard tester program that supports F13-F24
+5. Execute the BadUsb script via Flipper
+6. Notice the keypresses triggered, only the GUI key will be executed
+
+### Target
+
+_No response_
+
+### Logs
+
+_No response_
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04026-desfire-light-shows-as-unknown.md
+++ b/.ai/upstream-issues/04026-desfire-light-shows-as-unknown.md
@@ -1,0 +1,22 @@
+# Issue #4026: DESFire Light shows as unknown
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4026](https://github.com/flipperdevices/flipperzero-firmware/issues/4026)
+**Author:** @Bricolas
+**Created:** 2024-12-05T18:21:14Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Description of the feature you're suggesting.
+
+When reading à MIFARE DESFire Light card with the Flipper Zero, it should be shown as MIFARE DESFire Light.
+With all the available information as for a DESFire 4k or 8k card.
+![IMG_5111](https://github.com/user-attachments/assets/e5b276a2-dc24-499d-ba43-72e088386d70)
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04037-feature-request--crontab.md
+++ b/.ai/upstream-issues/04037-feature-request--crontab.md
@@ -1,0 +1,30 @@
+# Issue #4037: Feature Request: Crontab
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4037](https://github.com/flipperdevices/flipperzero-firmware/issues/4037)
+**Author:** @jblanked
+**Created:** 2024-12-18T02:10:43Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Hey, I talked about this with WillyJL and Aleksandr Kutuzov on Discord. 
+
+In short, it's the ability to run an app or service in the background. It could be used to:
+- start apps or run scripts at specific times
+- ability to start apps in the background
+- schedule an app or service to run in the background
+- frequent battery status checks in FindMyFlipper app
+- push notifications in FlipSocial
+
+Willy mentioned a method `furi_cron_schedule() `
+
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04063-rfid-card-not-recognized.md
+++ b/.ai/upstream-issues/04063-rfid-card-not-recognized.md
@@ -1,0 +1,36 @@
+# Issue #4063: RFID card not recognized
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4063](https://github.com/flipperdevices/flipperzero-firmware/issues/4063)
+**Author:** @Koopabro
+**Created:** 2025-01-07T10:51:37Z
+**Labels:** Feature Request, RFID 125kHz
+
+## Description
+
+### Describe the bug.
+
+RFID card is not recognized by Flipper Zero. The card has no markings or brandings, so I can't really check what kind of technology that is, but the reader operaties at 134,2 KHZ and the technology is called TIRIS. Brand of reader is Tiprox PR64. See also the raw RFID readings.
+[Archive.zip](https://github.com/user-attachments/files/18331371/Archive.zip)
+
+
+### Reproduction
+
+N/A
+
+### Target
+
+Flipper Zero
+
+### Logs
+
+```Text
+[Archive.zip](https://github.com/user-attachments/files/18331371/Archive.zip)
+```
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04072-bad-usb-feature-ignores-keyboard-layout-setting-d.md
+++ b/.ai/upstream-issues/04072-bad-usb-feature-ignores-keyboard-layout-setting-d.md
@@ -1,0 +1,65 @@
+# Issue #4072: Bad USB feature ignores keyboard layout setting (DE-CH)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4072](https://github.com/flipperdevices/flipperzero-firmware/issues/4072)
+**Author:** @ThWunderlin
+**Created:** 2025-01-18T21:04:30Z
+**Labels:** USB, Bug
+
+## Description
+
+### Describe the bug.
+
+When using the Bad USB feature with DE-CH keyboard layout selected, the Flipper Zero appears to still send US keyboard scancodes instead of using the selected layout.
+
+### Reproduction
+
+1. Set Flipper Zero Bad USB keyboard layout to DE-CH
+2. Connect to MacBook Pro with Swiss German keyboard layout (DE-CH)
+3. Run the default Bad USB demo script or a simple test script
+4. Observe character mapping issues
+
+
+Expected behavior:
+- Flipper Zero should send correct scancodes matching the selected DE-CH layout
+- Special characters should be correctly mapped for Swiss German layout
+
+Actual behavior:
+- Flipper Zero sends US keyboard scancodes regardless of selected layout
+- This causes incorrect character mapping on Swiss German MacOS:
+  - ! becomes +
+  - " becomes à
+  - § becomes ç
+  - ( becomes -
+  - ) remains )
+  - = becomes ^
+  - ? becomes _
+  - \ becomes 
+  - @ becomes ä
+  - # becomes *
+
+Test Environment:
+- Device: MacBook Pro
+- OS: MacOS with Swiss German (DE-CH) keyboard layout
+- Flipper Zero Firmware: [Your firmware version]
+- Also tested with Unleashed firmware with same results
+
+Additional Notes:
+- Same behavior observed with both official and Unleashed firmware
+- Changing Flipper Zero keyboard layout setting has no effect on the output
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04073-crash-with-rcp-app.md
+++ b/.ai/upstream-issues/04073-crash-with-rcp-app.md
@@ -1,0 +1,39 @@
+# Issue #4073: Crash with RCP app
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4073](https://github.com/flipperdevices/flipperzero-firmware/issues/4073)
+**Author:** @gaellalire
+**Created:** 2025-01-18T21:44:09Z
+**Labels:** Bug, Core+Services
+
+## Description
+
+### Describe the bug.
+
+When an RCP app is launched and not exited, the flipper crash with a fury message and pairing is lost.
+You should close the app gracefully when connection is lost.
+I tested with Sub-Ghz app but I guess it is for all RPC app.
+
+Bluetooth connection is not reliable, you should manage lost connections properly.
+
+### Reproduction
+
+1) Launch an app in RPC mode in bluetooth (probably same issue with USB) with a phone
+2) Disconnect (put the flipper in microwave for example)
+3) Check that flipper crashed with an exception 
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04079-export-ble-buffers-in-skd.md
+++ b/.ai/upstream-issues/04079-export-ble-buffers-in-skd.md
@@ -1,0 +1,21 @@
+# Issue #4079: Export BLE buffers in SKD
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4079](https://github.com/flipperdevices/flipperzero-firmware/issues/4079)
+**Author:** @loftyinclination
+**Created:** 2025-01-24T16:16:16Z
+**Labels:** Feature Request, Core+Services, Bluetooth
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+When sending BLE HCI commands to the STM32WB55 coprocessor (using the process laid out in Annex 5289, 14.2.2) the command body must first be written into the `p_cmdBuffer`. Currently, it's not possible to write to this buffer in third party applications, since it's not referenced in the SDK, and so it's not possible to build any applications that use HCI commands.
+
+(It is currently possible to listen for the responses to these events, via use of the `ble_event_dispatcher_register_svc_handler` function, which I think was included because the event handling is necessary for both ACI commands (which, as they don't require touching the `p_cmdBuffer`, are already callable from other applications), as well as HCI commands).
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04086-region-mhz-locks-are-incorrect-for-country-code-im.md
+++ b/.ai/upstream-issues/04086-region-mhz-locks-are-incorrect-for-country-code-im.md
@@ -1,0 +1,35 @@
+# Issue #4086: Region Mhz locks are incorrect for country code IM
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4086](https://github.com/flipperdevices/flipperzero-firmware/issues/4086)
+**Author:** @omalmighty
+**Created:** 2025-01-29T18:01:09Z
+**Labels:** Sub-GHz
+
+## Description
+
+### Describe the bug.
+
+Country code IM is in Region 1 which should have access to 433Mhz but is locking me out. 
+
+### Reproduction
+
+Be in country code IM
+run a frequency at 433.92Mhz
+get lock out message
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04089-bug-in-manual-read--effects-slix-nfc-possibly-oth.md
+++ b/.ai/upstream-issues/04089-bug-in-manual-read--effects-slix-nfc-possibly-oth.md
@@ -1,0 +1,39 @@
+# Issue #4089: Bug in Manual Read: effects slix nfc, possibly others
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4089](https://github.com/flipperdevices/flipperzero-firmware/issues/4089)
+**Author:** @FOSSBOSS
+**Created:** 2025-01-31T01:59:02Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the bug.
+
+When you select a manual Read NFC if the slix tag is not found, the read process never times out.
+
+### Reproduction
+
+1.switch on.
+2. navigate to NFC
+3. read
+4.Manual read
+5. select slix nfc 
+6. press read.
+7. wait for the moon cycle to complete when your battery runs out. or re-flash your firmware. you can not escape the sequence, and it never times out. 
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04104-question-regarding-nonconsistency-of-blocking-in.md
+++ b/.ai/upstream-issues/04104-question-regarding-nonconsistency-of-blocking-in.md
@@ -1,0 +1,19 @@
+# Issue #4104: Question regarding (non)consistency of blocking/internal animation manifests
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4104](https://github.com/flipperdevices/flipperzero-firmware/issues/4104)
+**Author:** @Kuronons
+**Created:** 2025-02-08T14:46:57Z
+**Labels:** Documentation
+
+## Description
+
+The [manifest](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/assets/dolphin/blocking/manifest.txt) of ***blocking animations*** shows all entries data to 0 (butthurt/lvl/weight) as those are meant to be called by their NAME when event occurs.
+So I was wondering why it wasn't the same regarding the ***internal animations*** [manifest](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/assets/dolphin/internal/manifest.txt) where the listed anims too are meant to be called by NAME on specific event.
+As far as I understand it, this doesn't seem to have any impact but in terms of **consistency** it seems a bit off to me especially when in the [readme](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/assets/dolphin/ReadMe.md) you have this being written : 
+
+![image](https://github.com/user-attachments/assets/9abfb432-259f-49de-8c59-5fc736432bd6)
+
+Now, I might be missing something or even being totally wrong as my coding knowledge is pretty low... awaiting your enlightment if ever ! 
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04106-nfc-reading-issue-with-iso-14443-3a-mifare-ultrali.md
+++ b/.ai/upstream-issues/04106-nfc-reading-issue-with-iso-14443-3a-mifare-ultrali.md
@@ -1,0 +1,205 @@
+# Issue #4106: NFC Reading Issue with ISO 14443-3A Mifare Ultralight Card
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4106](https://github.com/flipperdevices/flipperzero-firmware/issues/4106)
+**Author:** @suaveolent
+**Created:** 2025-02-12T08:52:02Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the bug.
+
+When attempting to read an ISO 14443-3A Mifare Ultralight card (ATQA: 0x0044, SAK: 0x00), the Flipper Zero device gets stuck on the "Don't Move" screen. The debug output indicates multiple FWT timeouts and failures in reading the ATS and signature from the card.
+
+If I read it as "Specific Card Type" and select ISO14443-3A is correctly identifies the UID, however shows it as ISO14443-3A (Unknown)
+
+### Reproduction
+
+1. Attempt to read above mentioned ISO 14443-3A Mifare Ultralight card with the NFC application
+2. Observe the device getting stuck on the "Don't Move" screen.
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+489563 [D][NfcScanner] Found 5 base protocols
+489568 [D][DolphinState] icounter 1065, butthurt 14
+489603 [D][Nfc] FWT Timeout
+489626 [D][Nfc] FWT Timeout
+489677 [D][Nfc] FWT Timeout
+489699 [D][Nfc] FWT Timeout
+489725 [D][NfcScanner] Found 5 children
+489769 [D][Nfc] FWT Timeout
+489802 [D][Nfc] FWT Timeout
+489832 [D][Nfc] FWT Timeout
+489833 [E][Iso14443_4aPoller] ATS request failed
+489836 [D][Iso14443_4aPoller] Failed to read ATS
+489839 [D][Nfc] FWT Timeout
+489876 [D][Nfc] FWT Timeout
+489877 [E][Iso14443_4aPoller] ATS request failed
+489880 [D][Iso14443_4aPoller] Failed to read ATS
+489883 [D][Nfc] FWT Timeout
+489897 [I][NfcScanner] Detected 1 protocols
+490006 [W][ViewPort] ViewPort lockup: see applications/services/gui/view_port.c:245
+490064 [I][Elf] Total size of loaded sections: 888
+490067 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490112 [I][Elf] Total size of loaded sections: 420
+490115 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490170 [I][Elf] Total size of loaded sections: 1804
+490173 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490240 [I][Elf] Total size of loaded sections: 3212
+490243 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490290 [I][Elf] Total size of loaded sections: 284
+490293 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490353 [I][Elf] Total size of loaded sections: 1356
+490356 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490402 [I][Elf] Total size of loaded sections: 820
+490405 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490454 [I][Elf] Total size of loaded sections: 1844
+490457 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490503 [I][Elf] Total size of loaded sections: 548
+490506 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490571 [I][Elf] Total size of loaded sections: 1396
+490574 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490628 [I][Elf] Total size of loaded sections: 1608
+490631 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490680 [I][Elf] Total size of loaded sections: 908
+490683 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490746 [I][Elf] Total size of loaded sections: 1212
+490749 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+490912 [E][Elf] Failed to resolve address for symbol div (hash B886A48)
+490916 [E][Elf] Error relocating section '.text'
+490918 [I][Elf] Total size of loaded sections: 5044
+490978 [I][Elf] Total size of loaded sections: 4568
+490981 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491036 [I][Elf] Total size of loaded sections: 4560
+491039 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491089 [I][Elf] Total size of loaded sections: 1324
+491092 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491151 [I][Elf] Total size of loaded sections: 3276
+491154 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491210 [I][Elf] Total size of loaded sections: 1144
+491213 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491297 [I][Elf] Total size of loaded sections: 9532
+491300 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491358 [I][Elf] Total size of loaded sections: 1956
+491361 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491409 [I][Elf] Total size of loaded sections: 368
+491412 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491464 [I][Elf] Total size of loaded sections: 1464
+491467 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491518 [I][Elf] Total size of loaded sections: 636
+491521 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491584 [I][Elf] Total size of loaded sections: 1024
+491587 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+491591 [D][NfcSupportedCards] Loaded 24 plugins
+491608 [D][MfUltralightPoller] Read version success
+491611 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491614 [D][MfUltralightPoller] Reading signature
+491622 [D][MfUltralightPoller] Read signature failed
+491624 [D][MfUltralightPoller] Read Failed
+491627 [D][Nfc] FWT Timeout
+491636 [D][MfUltralightPoller] Read version success
+491639 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491642 [D][MfUltralightPoller] Reading signature
+491650 [D][MfUltralightPoller] Read signature failed
+491652 [D][MfUltralightPoller] Read Failed
+491655 [D][Nfc] FWT Timeout
+491664 [D][MfUltralightPoller] Read version success
+491667 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491670 [D][MfUltralightPoller] Reading signature
+491678 [D][MfUltralightPoller] Read signature failed
+491680 [D][MfUltralightPoller] Read Failed
+491683 [D][Nfc] FWT Timeout
+491692 [D][MfUltralightPoller] Read version success
+491695 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491698 [D][MfUltralightPoller] Reading signature
+491706 [D][MfUltralightPoller] Read signature failed
+491708 [D][MfUltralightPoller] Read Failed
+491711 [D][Nfc] FWT Timeout
+491720 [D][MfUltralightPoller] Read version success
+491723 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491726 [D][MfUltralightPoller] Reading signature
+491734 [D][MfUltralightPoller] Read signature failed
+491736 [D][MfUltralightPoller] Read Failed
+491739 [D][Nfc] FWT Timeout
+491748 [D][MfUltralightPoller] Read version success
+491751 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491754 [D][MfUltralightPoller] Reading signature
+491762 [D][MfUltralightPoller] Read signature failed
+491764 [D][MfUltralightPoller] Read Failed
+491767 [D][Nfc] FWT Timeout
+491776 [D][MfUltralightPoller] Read version success
+491779 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491782 [D][MfUltralightPoller] Reading signature
+491790 [D][MfUltralightPoller] Read signature failed
+491792 [D][MfUltralightPoller] Read Failed
+491795 [D][Nfc] FWT Timeout
+491804 [D][MfUltralightPoller] Read version success
+491807 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491810 [D][MfUltralightPoller] Reading signature
+491818 [D][MfUltralightPoller] Read signature failed
+491820 [D][MfUltralightPoller] Read Failed
+491823 [D][Nfc] FWT Timeout
+491832 [D][MfUltralightPoller] Read version success
+491835 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491838 [D][MfUltralightPoller] Reading signature
+491846 [D][MfUltralightPoller] Read signature failed
+491848 [D][MfUltralightPoller] Read Failed
+491851 [D][Nfc] FWT Timeout
+491860 [D][MfUltralightPoller] Read version success
+491863 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491866 [D][MfUltralightPoller] Reading signature
+491874 [D][MfUltralightPoller] Read signature failed
+491876 [D][MfUltralightPoller] Read Failed
+491879 [D][Nfc] FWT Timeout
+491888 [D][MfUltralightPoller] Read version success
+491891 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491894 [D][MfUltralightPoller] Reading signature
+491902 [D][MfUltralightPoller] Read signature failed
+491904 [D][MfUltralightPoller] Read Failed
+491907 [D][Nfc] FWT Timeout
+491916 [D][MfUltralightPoller] Read version success
+491918 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491922 [D][MfUltralightPoller] Reading signature
+491929 [D][MfUltralightPoller] Read signature failed
+491932 [D][MfUltralightPoller] Read Failed
+491935 [D][Nfc] FWT Timeout
+491944 [D][MfUltralightPoller] Read version success
+491947 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491950 [D][MfUltralightPoller] Reading signature
+491958 [D][MfUltralightPoller] Read signature failed
+491960 [D][MfUltralightPoller] Read Failed
+491963 [D][Nfc] FWT Timeout
+491972 [D][MfUltralightPoller] Read version success
+491975 [D][MfUltralightPoller] NTAG213 detected. Total pages: 45
+491978 [D][MfUltralightPoller] Reading signature
+491986 [D][MfUltralightPoller] Read signature failed
+491988 [D][MfUltralightPoller] Read Failed
+491991 [D][Nfc] FWT Timeout
+```
+
+### Anything else?
+
+**Output from NFC tools:**
+
+_Tag Type: ISO 14443-3A_
+NXP - Mifare Ultralight (Ultralight)
+
+_Technologies available_
+NfcA, MifareUltralight, NdefFormatable
+
+_Serial number_
+04:79:CC:FA:9D:1D:90
+
+_ATQA_
+0x0044
+
+_SAK_
+0x00
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04108-nfc-bus-fault.md
+++ b/.ai/upstream-issues/04108-nfc-bus-fault.md
@@ -1,0 +1,42 @@
+# Issue #4108: NFC bus fault
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4108](https://github.com/flipperdevices/flipperzero-firmware/issues/4108)
+**Author:** @foXaCe
+**Created:** 2025-02-13T17:23:42Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+Hello, 
+when I select an already saved NFC file and try to write to the original card, I get this error message. I
+get this message with any NFC file and card. I should mention that before, 
+I didn't have this error message and everything worked fine.
+
+
+
+### Reproduction
+
+1 NFC
+2 SAVED
+3 SELECT ONE
+4 WRITE TO INITIAL CARD
+
+### Target
+
+_No response_
+
+
+```Text
+
+```
+
+### Anything else?
+
+![Image](https://github.com/user-attachments/assets/330c710c-f56c-42ce-8f74-970c04ad30a8)
+
+[qFlipper-20250213-182039.txt](https://github.com/user-attachments/files/18787716/qFlipper-20250213-182039.txt)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04130-hook-for-favorites-menu.md
+++ b/.ai/upstream-issues/04130-hook-for-favorites-menu.md
@@ -1,0 +1,24 @@
+# Issue #4130: Hook for Favorites menu
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4130](https://github.com/flipperdevices/flipperzero-firmware/issues/4130)
+**Author:** @leedave
+**Created:** 2025-02-26T16:35:01Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Many apps are using their own file types. It would be nice to have an option to include the file types into the Favorites menu. 
+- registration of file suffix
+- map it to an app that can open the file type
+- assign a custom icon to the file type
+
+I've seen custom firmware manually including different file types for the favorites menu (or app/main/archive). It would be cool if there was a dynamic way of doing this. Like a field in the apps manifest that allows to suggest an app to be the opener of a specific file type. 
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04138-add-two-bart-stations-to-clipper-database.md
+++ b/.ai/upstream-issues/04138-add-two-bart-stations-to-clipper-database.md
@@ -1,0 +1,30 @@
+# Issue #4138: Add two BART Stations to Clipper Database
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4138](https://github.com/flipperdevices/flipperzero-firmware/issues/4138)
+**Author:** @Davis-P0
+**Created:** 2025-03-04T12:44:37Z
+**Labels:** Feature Request, NFC
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+There are two stations missing from the BART Station list in 
+applications/main/nfc/plugins/supported_cards/clipper.c
+
+{.id = 0x0031, .name = "Pittsburg Center"}, // Assumed - only one missing
+{.id = 0x0032, .name = "Antioch"} // Verified
+
+I can take a trip to Pittsburg Center to verify the code, if you wish.  I work for BART and sometimes use Antioch, and that code comes up as 0x0032 on my card.
+
+Thanks for creating the project.
+
+--Dave P
+
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04148-badusb-script-runs-too-fast-for-notepad.exe-on-win.md
+++ b/.ai/upstream-issues/04148-badusb-script-runs-too-fast-for-notepad.exe-on-win.md
@@ -1,0 +1,31 @@
+# Issue #4148: BadUSB script runs too fast for notepad.exe on Windows 11
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4148](https://github.com/flipperdevices/flipperzero-firmware/issues/4148)
+**Author:** @ase1590
+**Created:** 2025-03-12T19:40:43Z
+**Labels:** Triage
+
+## Description
+
+### Describe the bug.
+
+The current BadUSB STRING input speed the the Flipper provides in 1.2.0 by default exceed that which Windows can reliably keep up with. 
+
+Running the Demo_Windows script will result in multiple missed characters, as will any script that has long amounts of string input.  
+
+### Reproduction
+
+1. run BadUSB
+2. run the demo_windows.txt script 
+3. note that the input is too fast, and characters are missed. 
+
+### Target
+
+1.2.0
+
+Edit: this seems specific to Windows 11 and notepad.exe
+see my comment [here](https://github.com/flipperdevices/flipperzero-firmware/issues/4148#issuecomment-2719719881)
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04152-i2c-slave-mode.md
+++ b/.ai/upstream-issues/04152-i2c-slave-mode.md
@@ -1,0 +1,21 @@
+# Issue #4152: I2C Slave mode
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4152](https://github.com/flipperdevices/flipperzero-firmware/issues/4152)
+**Author:** @TheSainEyereg
+**Created:** 2025-03-18T16:58:07Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I need to communicate with other devices (like ESP32 or maybe other Flippers) using I2C, so I can't always be a master.
+
+Is there any possibility to use my Flipper Zero as I2C slave? There's no mention in furi_hal documentation about I2C slave other than communicating with it.
+
+### Anything else?
+
+I saw STM32WB55RG datasheet and there is no clear distinct between I2C master and slave (which wasn't mentioned at all) modes, so It's possible that the same pins are used for master and slave modes. Only thing that possibly needed is software support for I2CSL.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04162-connecting-as-usb-hid-keyboard-cannot-read-state-o.md
+++ b/.ai/upstream-issues/04162-connecting-as-usb-hid-keyboard-cannot-read-state-o.md
@@ -1,0 +1,75 @@
+# Issue #4162: Connecting as USB HID keyboard cannot read state of keyboard LEDs (CapsLock/NumLock/ScrollLock)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4162](https://github.com/flipperdevices/flipperzero-firmware/issues/4162)
+**Author:** @maxplank
+**Created:** 2025-03-26T18:07:07Z
+**Labels:** USB, Triage
+
+## Description
+
+### Describe the bug.
+
+I'm developing an application that uses Flipper to connect to a computer and represent itself as USB keyboard (something similar to BadUSB).
+
+I'm able to establish connection using `furi_hal_usb_set_config()` and simulate key presses using `furi_hal_hid_kb_press()`.
+
+The problem is that it seems the method `furi_hal_hid_get_led_state()` is not working and always returns 0 no matter what the keyboard LEDs are blinking and no matter Caps/Num/Scroll Lock is toggled from the keyboard or by Flipper (actually I can simulate CapsLock press from Flipper and the physical keyboard toggles CapsLock LED).
+
+I dug deep into the firmware source code and I think I spotted where the problem comes from.
+Unfortunately I see no way it to be resolved from the external .fap application and it indeed needs fix in the firmware itself.
+
+So here is what I found:
+In "targets/f7/furi_hal/furi_hal_usb_hid.c":
+- `furi_hal_hid_get_led_state()` just returns led_state variable which is set in `hid_txrx_ep_callback()`
+- this one is registered as endpoint in `hid_ep_config()` with this line:
+	`usbd_reg_endpoint(dev, HID_EP_IN, hid_txrx_ep_callback);`
+
+I think the problem is that it is registered as HID_EP_IN only, which means one-way input only communication (device to host). There is no OUT endpoint registered (host to device) that would allow sending the LEDs state.
+
+For comparison there is something very similar in "targets/f7/furi_hal/furi_hal_usb_u2f.c" where there is additional line:
+	`usbd_reg_endpoint(dev, HID_EP_OUT, hid_u2f_txrx_ep_callback);`
+and this allows 2-way input/output communication.
+
+I believe that adding the relevant lines for HID_EP_OUT in "furi_hal_usb_hid.c" would fix the problem and allow the USB HID device to have full input/output communication.
+
+### Reproduction
+
+1. Create new Flipper Zero app.
+2. Connect as USB HID keyboard using:
+	`furi_hal_usb_set_config(...);`
+3. Simulate keypresses of CapsLock key (try several times):
+      ```
+      usb_keyboard_press(HID_KEY_CAPS_LOCK);
+      furi_delay_ms(50);
+      usb_keyboard_release(HID_KEY_CAPS_LOCK);
+4. Press CapsLock on the physical keyboard. Try several times.
+5. (Optional) Connect second physical keyboard and make sure CapsLock LED on both is synchronized.
+6. Call `furi_hal_hid_get_led_state()` and print its result.
+
+Expected:
+`furi_hal_hid_get_led_state()` returns value corresponding to keyboards' LEDs state.
+
+Actual result:
+`furi_hal_hid_get_led_state()` always returns 0
+
+### Target
+
+Source code: flipperzero-firmware dev branch, latest version (till this date)
+Flipper Zero device: Momentum mntm-009 [23-01-2025] (latest stable till this date)
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+Please provide a fix for this issue!
+The application I'm developing is exactly in the spirit of Flipper, but it is pointless without the ability to read keyboard LEDs, so I'm heavily relying on it. If everything goes smooth I hope to publish it, so it becomes a useful part of the Flipper toolkit.
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04194-technical-specification-for-flipper-zero-mifare-cl.md
+++ b/.ai/upstream-issues/04194-technical-specification-for-flipper-zero-mifare-cl.md
@@ -1,0 +1,74 @@
+# Issue #4194: Technical Specification for Flipper Zero Mifare Classic 1K Enhancement
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4194](https://github.com/flipperdevices/flipperzero-firmware/issues/4194)
+**Author:** @x133t
+**Created:** 2025-04-19T17:33:16Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+## 1. Introduction
+
+I have tested the Flipper Zero with ISO14443-A MIFARE Classic 1K standard and discovered several serious issues that need to be addressed. These problems are particularly acute when working with tags that have an MF filter.
+
+## 2. Issues Discovered
+
+### 2.1 Problems with Iron Logic technology.
+
+There is an issue with dumping data from cards and key vulnerabilities in Mifare Classic 1k cards programmed by an intercom company that uses Iron Logic readers.
+
+KDF is a key derivation function. It's possible to calculate the key by knowing the UID in Mifare Classic 1k cards, definitely using at least 4 bytes. This was accomplished by the Russian company ikeybase, but for some reason no one has been able to crack this algorithm, and they keep it secret—they have access to sector 14 KK KeyA. If you have any hints about how this works, specifically how the prediction key is calculated from the UID, I would be very grateful.
+
+### 2.2 Problems with Unknown Keys
+
+I also tested another tag with UID 96B8A921 (with MF3 filter), whose keys were unknown to me. The key recovery methods built into Flipper Zero proved ineffective - it takes too much time. I tried using various known vulnerabilities (nested, hardnested, darkside), but none of them helped.
+
+However, TMD-5S and SMKey with ikeybase express software very quickly recovered the keys through their server algorithm:
+
+- Key A: EF 41 40 37 DC F6
+- Key B: B6 DA 90 FE 2D E0
+
+When I took these keys and used Flipper Zero to write to an empty MF3 tag, the result was successful - the copy opened the intercom door.
+
+### 2.3 Problems with Reading Sectors
+
+I also noticed that Flipper Zero doesn't always reliably read all sectors. This depends on the type of tag - some are read completely, others only partially.
+
+## 3. Required Improvements
+
+### Test 1: Working with system KDF
+
+We need to try implementing a KDF for sector 14 that would generate keys based on the UID.
+
+### Test 2: Recovery of Unknown Keys
+
+Tag with unknown keys (for example, with UID 96B8A921) and I will verify that:
+
+- Keys are recovered within a reasonable time (no more than 2 minutes)
+- The recovered keys are correct (for example, Key A: EF 41 40 37 DC F6, Key B: B6 DA 90 FE 2D E0)
+- When writing data to an empty MF3 tag, the copy works like the original
+
+### Test 3: Reading Stability
+
+I will check various types of tags with MF3 filter and be convinced that:
+
+- All sectors are successfully read
+- Or for example, implement a nested attack in a phone application with Bluetooth connection to the Flipper. The application would take the file from the log in ext/nfc/.nested.log and the smartphone copies it via Bluetooth, converts .nested.log to .nonce format, and then decrypts it from .nonce to .nfc dictionary by itself, as smartphones have more computing power.
+- Reading results are stable during repeated scans of the same tag.
+
+
+[test_original.nfc.json](https://github.com/user-attachments/files/19822212/test_original.nfc.json)
+
+[hf-mf-E3D143BD-dump.json](https://github.com/user-attachments/files/19822215/hf-mf-E3D143BD-dump.json)
+
+[test_E3D143BD.nfc.json](https://github.com/user-attachments/files/19822232/test_E3D143BD.nfc.json)
+
+[96B8A921.nfc.json](https://github.com/user-attachments/files/19822211/96B8A921.nfc.json)
+[2573B480.nfc.json](https://github.com/user-attachments/files/19822210/2573B480.nfc.json)
+
+[Video: Original Tag](https://youtu.be/PUBvl1T7aiY)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04196-technical-specification--nfc-tag-information-appli.md
+++ b/.ai/upstream-issues/04196-technical-specification--nfc-tag-information-appli.md
@@ -1,0 +1,58 @@
+# Issue #4196: Technical Specification: NFC Tag Information Application for Flipper Zero
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4196](https://github.com/flipperdevices/flipperzero-firmware/issues/4196)
+**Author:** @x133t
+**Created:** 2025-04-19T18:35:44Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Description of the feature you're suggesting.
+
+## Project Overview
+
+I need an application for Flipper Zero that will read detailed information about NFC tags, similar to how Proxmark, TMD-5S, or SMKey devices operate. This should be a standalone application that quickly identifies the tag type before proceeding to read it with the scanner.
+
+## Application Requirements
+
+I want the application to:
+
+- Scan ISO14443-A tags (primarily MIFARE Classic 1K standard)
+- Display all critical technical information about the tag:
+  - UID (unique identifier)
+  - ATQA
+  - SAK
+  - Tag type (e.g., "MIFARE Classic 1K")
+  - RATS support status
+  - Static nonce information
+  - Hints for further actions
+
+It's especially important that the application can detect the presence and type of filter on the tag (MF1, MF2, MF3, OTP, ZERO, and others).
+
+## Current Issues
+
+I've attempted to write this application myself but encountered errors. In my implementation, the application doesn't detect filters like TDM-5S or Proxmark do, and produces the following errors in the logs:
+
+```
+122528 [D][Nfc] FWT Timeout
+122579 [E][Iso14443_4aPoller] ATS request failed
+122582 [D][Iso14443_4aPoller] Failed to read ATS
+```
+
+## Development Considerations
+
+- The application should work quickly (no more than 3 seconds per scan)
+- It should handle errors correctly
+- It should use the NFC libraries from the Flipper Zero SDK
+- It should implement retry attempts to improve reliability
+
+I've attached the source code of my implementation for further analysis and development. I would appreciate help in solving these issues!
+
+[TMD-5S](https://github.com/user-attachments/assets/58530c2b-cdd7-4102-91b4-5878d1410d58)
+
+[Video: Check NFC](https://youtu.be/dH3hJeDYR00)
+
+[Nfc Tag Detector.zip](https://github.com/user-attachments/files/19822442/Nfc.Tag.Detector.zip)
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04200-enhance-subghz-with-protocol-command-cycling.md
+++ b/.ai/upstream-issues/04200-enhance-subghz-with-protocol-command-cycling.md
@@ -1,0 +1,35 @@
+# Issue #4200: Enhance SubGhz with protocol command cycling
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4200](https://github.com/flipperdevices/flipperzero-firmware/issues/4200)
+**Author:** @Nvidiacerv
+**Created:** 2025-04-21T07:52:08Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+** may 5 update, i made an enhanced subghz app and got this feature to work. At this moment it is working for only the intertechno_v3 protocol but looking to expand it to support more protocols soon. I saved this enhancement in a private repository for the flipper team to look at. Contact me for access. I wanna contribute to the flipper zero firmware but unexperienced with github.
+
+**1. Goal:** Enhance the SubGHz signal emulation functionality to allow users to transmit different commands associated with a specific device/protocol, beyond simply replaying the exact command that was originally captured and saved.
+**2. Current Limitation:** Currently, if a user captures and saves, for example, the "Close" command for a Dooya blind remote, the "Send" function can only re-transmit that exact "Close" command. To send "Open" or "Stop", the user must capture and save those specific signals separately or edit the sub file manually for instance using an editor on a pc.
+**3. Desired Enhancement:** When a user selects a saved SubGHz key for emulation (sending), the system should:
+       • Identify Supported Commands: Determine if the protocol associated with the saved key supports multiple distinct commands (e.g., On/Off, Open/Close/Stop).
+       • Present Options (If Applicable): If multiple commands are supported, present the user with a choice of available commands for that protocol before transmission. This list should use human-readable names. The user should be able to select another command for instance by using the up or down button on the flipper zero while in the emulation screen.
+       • Generate Selected Command: Upon user selection of a command (which might be the original command or a different one from the list), the system must generate the correct SubGHz signal payload corresponding to the selected command when send is pressed.
+       • Reuse Identification Data: Crucially, the newly generated signal must utilize the essential identification parameters (like Device ID, Remote Address, Channel, Key, Counter - depending on the protocol) from the original saved key. This ensures the command is sent as if from the original remote and targets the correct receiving device.
+**4. Examples for the Dooya and Intertechno_V3 protocols. But should be workign with all known commands with multiple commands:**
+       • Dooya Protocol (Blinds/Curtains):
+           ◦ User saves a key captured from the "Close" button.
+           ◦ User selects this key and chooses "Send".
+           ◦ The system recognizes it's Dooya and presents options: "Open", "Close", "Stop".
+           ◦ User selects "Open".
+           ◦ The system generates the "Open" command signal, using the Device ID and other necessary data from the saved "Close" key, and transmits it.
+       • Intertechno V3 Protocol (Power Outlets):
+           ◦ User saves a key captured from the "On" button for a specific outlet address.
+           ◦ User selects this key and chooses "Send".
+           ◦ The system recognizes it's Intertechno V3 and presents options: "On", "Off".
+           ◦ User selects "Off".
+           ◦ The system generates the "Off" command signal, using the address/ID from the saved "On" key, and transmits it.
+**5. Benefit:** This feature allows users to fully control devices supporting multiple commands using only a single saved key for that device, significantly improving usability and reducing the need to capture every possible command variation. It transforms the Flipper from a simple repeater into a more versatile remote control for supported protocols.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04209-nfc-incorrect-mapping-of-ultralight-c-in-memory.md
+++ b/.ai/upstream-issues/04209-nfc-incorrect-mapping-of-ultralight-c-in-memory.md
@@ -1,0 +1,50 @@
+# Issue #4209: [NFC] Incorrect mapping of Ultralight C in memory
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4209](https://github.com/flipperdevices/flipperzero-firmware/issues/4209)
+**Author:** @mishamyte
+**Created:** 2025-05-02T21:39:21Z
+**Labels:** NFC, Bug
+
+## Description
+
+### Describe the bug.
+
+According to [Ultralight C datasheet](https://www.nxp.com/docs/en/data-sheet/MF0ICU2.pdf), 16-bytes 3DES key is stored in 4 memory pages. 
+It's logically separated to Key1, Key2 with lengths of 8 bytes.
+
+Key1 and Key2 stored in corresponding memory pages in **reverse** order.
+
+![Image](https://github.com/user-attachments/assets/c2902877-e4c3-476a-9803-bff6501d4092)
+
+In current implementation (NFC file version **v4**) data is stored as is, which is conceptually wrong and could lead to unexpected side-effects for tools, which can work with that file. 
+
+For example, key from referenced datasheet sample is stored in a next form:
+
+![Image](https://github.com/user-attachments/assets/1be52048-5ab7-463f-838d-9f45970a7653)
+
+For workflow it's now an issue, because key is also loaded in a memory as is and interpreted correctly.
+
+Behavior can be changed (for persisting/unpersisting key), but it will be a breaking change and potentially can be solved by bumping the schema version (to v5 for example).
+
+### Reproduction
+
+1. Read Mifare Ultralight C with key
+2. Save it
+3. Open in text editor and check key representation in dump
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04214-furi_hal_hid_get_led_state-returns-0-regardless-.md
+++ b/.ai/upstream-issues/04214-furi_hal_hid_get_led_state-returns-0-regardless-.md
@@ -1,0 +1,37 @@
+# Issue #4214: furi_hal_hid_get_led_state() returns 0 regardless of keyboard state
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4214](https://github.com/flipperdevices/flipperzero-firmware/issues/4214)
+**Author:** @mantacid
+**Created:** 2025-05-05T15:50:49Z
+**Labels:** JS, Triage
+
+## Description
+
+### Describe the bug.
+
+While trying to write a program that could obtain the status of the host device's lock keys, I noticed that the function that would allow me to do so (`furi_hal_hid_get_led_state`) would always return 0, regardless of the state of the hsot keyboard
+
+### Reproduction
+
+1. Load the attached javascript onto the flipper (github wouldn't let me upload the js file directly).
+2. while the flipper is connected to a computer, run the script.
+3. attempt to toggle the caps lock key during execution.
+
+[bugtest copy.txt](https://github.com/user-attachments/files/20039694/bugtest.copy.txt)
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+I'm running the momentum firmware, but have reason to believe that this is an issue on stock as well.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04218-buetooth-why-is-the-extra-beacon-size-limited-to.md
+++ b/.ai/upstream-issues/04218-buetooth-why-is-the-extra-beacon-size-limited-to.md
@@ -1,0 +1,17 @@
+# Issue #4218: [Buetooth] Why is the extra beacon size limited to 31?
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4218](https://github.com/flipperdevices/flipperzero-firmware/issues/4218)
+**Author:** @steam3d
+**Created:** 2025-05-08T20:24:46Z
+**Labels:** Feature Request, Bluetooth
+
+## Description
+
+Hi. In the main page description, it says that Flipper uses Bluetooth LE 5.4 (possibly STM32WB55), but I did not find the exact model. Does it really support only 31 bytes of beacon size?
+
+It looks like it uses Legacy Advertising, but can we get Extended Advertising with up to 255 bytes of beacon size?
+
+https://github.com/flipperdevices/flipperzero-firmware/blob/5b911f5405f104ad3e3051aa70e2a50a5b2a6d16/targets/f7/ble_glue/extra_beacon.c#L119
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04247-nfc-files-not-syncing-via-bluetooth-from-flipper-t.md
+++ b/.ai/upstream-issues/04247-nfc-files-not-syncing-via-bluetooth-from-flipper-t.md
@@ -1,0 +1,33 @@
+# Issue #4247: NFC files not syncing via Bluetooth from Flipper to Android app (v1.8)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4247](https://github.com/flipperdevices/flipperzero-firmware/issues/4247)
+**Author:** @KevinLiebergen
+**Created:** 2025-07-03T08:22:26Z
+**Labels:** Bluetooth, Triage
+
+## Description
+
+### Describe the bug.
+
+Hi, I'm currently using the Flipper Zero (v1.3.4) with the Android app (v1.8 – latest release from November 2024), and I'm having trouble syncing NFC files via Bluetooth.
+
+The NFC files are definitely being saved on the Flipper, since I can see them when I connect the device to a computer via USB and browse the file system. However, they don't appear in the Android app.
+
+I've tried uninstalling and reinstalling the APK, and also confirmed that RFID and SubGHz files sync correctly via Bluetooth, only NFC files are missing.
+
+I haven't found any open issues related to this, and after a bit of searching, I couldn't find any similar reports online. Has anyone else encountered this issue or found a workaround?
+
+Thanks in advance!
+
+### Reproduction
+
+1. Power on Flipper Zero and connect it to the Android app (v1.8) via Bluetooth.
+2. Scan an NFC tag using the Flipper.
+3. Open the Android app and go to the "NFC" section.
+4. Observe that the scanned NFC file does not appear in the app.
+5. Connect the Flipper to a computer via USB and browse the internal storage.
+6. Confirm that the NFC file exists on the device.
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04248-inconsistent-file-path-syntax-in-cli.md
+++ b/.ai/upstream-issues/04248-inconsistent-file-path-syntax-in-cli.md
@@ -1,0 +1,31 @@
+# Issue #4248: Inconsistent file path syntax in CLI
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4248](https://github.com/flipperdevices/flipperzero-firmware/issues/4248)
+**Author:** @Stichoza
+**Created:** 2025-07-11T14:59:11Z
+**Labels:** Backlog, Bug, Core+Services
+
+## Description
+
+CLI commands that have spaces in filename are handled inconsistently throughout Flipper CLI.
+
+Examples:
+
+#### `storage read` – Normal behavior
+- `storage read /ext/subghz/Some File.sub` – Does not work.
+- `storage read "/ext/subghz/Some File.sub"` – Works with path in quotes.
+
+#### `loader open` – Opposite behavior of normal
+- `loader open subghz /ext/subghz/Some File.sub` – Works even without quotes.
+- `loader open subghz "/ext/subghz/Some File.sub"` – Fails with quotes.
+
+#### `subghz tx_from_file` – Not working at all
+- `subghz tx_from_file /ext/subghz/Some File.sub` – No quotes – not working
+- `subghz tx_from_file /ext/subghz/Some\ File.sub` – Escaped space – not working
+- `subghz tx_from_file "/ext/subghz/Some File.sub"` – Double quotes – not working
+- `subghz tx_from_file '/ext/subghz/Some File.sub'` – Single quotes – not working
+
+Inconsistency between `storage read` and `loader open` is not a big deal, but I'm unable to make `subghz tx_from_file` work.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04249-reading-nfc-card-while-connected-via-usb-to-a-comp.md
+++ b/.ai/upstream-issues/04249-reading-nfc-card-while-connected-via-usb-to-a-comp.md
@@ -1,0 +1,128 @@
+# Issue #4249: Reading NFC card while connected via USB to a computer and to qFlipper leads to a OOM Crash
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4249](https://github.com/flipperdevices/flipperzero-firmware/issues/4249)
+**Author:** @hac-v
+**Created:** 2025-07-11T18:02:28Z
+**Labels:** NFC, Triage
+
+## Description
+
+### Describe the bug.
+
+Firmware version 1.3.4.
+
+$SUBJECT.
+
+### Reproduction
+
+1. Connect to a computer via USB cable;
+2. Select "Read" to read an NFC card;
+3. Observe the "out of memory" crash message before anything else appears on the screen.
+
+
+The reproducer is reliable for me.
+
+*[see log below]* ~~However, when I use the dev board to collect debug logs, the crash does not happen. I am not sure of the reason (I'm new to flipper, got mine two days ago). If there are better ways to collect this other than connecting the dev board to FlipperZero and via USB to a computer, let me know. ~~
+
+### Target
+
+_No response_
+
+### Logs
+
+Was able to reproduce by tapping buttons on the UI.
+
+```Text
+488376 [I][Elf] Total size of loaded sections: 888
+488379 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488426 [I][Elf] Total size of loaded sections: 420
+488429 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488449 [D][RpcGui] SendInputEvent
+488459 [D][RpcGui] SendInputEvent
+488498 [I][Elf] Total size of loaded sections: 1804
+488501 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488554 [I][Elf] Total size of loaded sections: 3212
+488557 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488622 [I][Elf] Total size of loaded sections: 4892
+488625 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488675 [I][Elf] Total size of loaded sections: 284
+488678 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488736 [I][Elf] Total size of loaded sections: 1356
+488739 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488779 [D][RpcGui] SendInputEvent
+488793 [I][Elf] Total size of loaded sections: 820
+488796 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488856 [I][Elf] Total size of loaded sections: 1844
+488860 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488863 [D][RpcGui] SendInputEvent
+488870 [D][RpcGui] SendInputEvent
+488916 [I][Elf] Total size of loaded sections: 548
+488919 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+488942 [D][RpcGui] SendInputEvent
+488980 [I][Elf] Total size of loaded sections: 1396
+488983 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489029 [D][RpcGui] SendInputEvent
+489046 [I][Elf] Total size of loaded sections: 1608
+489049 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489053 [D][RpcGui] SendInputEvent
+489104 [I][Elf] Total size of loaded sections: 908
+489107 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489177 [I][Elf] Total size of loaded sections: 1212
+489180 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489196 [E][Elf] Not enough memory to load section data
+489198 [E][Elf] Error loading section '.text'
+489201 [E][Elf] Not enough memory
+489215 [E][Elf] Not enough memory to load section data
+489218 [E][Elf] Error loading section '.text'
+489221 [E][Elf] Not enough memory
+489235 [E][Elf] Not enough memory to load section data
+489238 [E][Elf] Error loading section '.text'
+489242 [E][Elf] Not enough memory
+489301 [I][Elf] Total size of loaded sections: 1324
+489304 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489360 [I][Elf] Total size of loaded sections: 3276
+489363 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489416 [I][Elf] Total size of loaded sections: 1144
+489419 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489445 [E][Elf] Not enough memory to load section data
+489448 [E][Elf] Error loading section '.text'
+489451 [E][Elf] Not enough memory
+489505 [I][Elf] Total size of loaded sections: 1956
+489508 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489560 [I][Elf] Total size of loaded sections: 368
+489563 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489618 [I][Elf] Total size of loaded sections: 1464
+489621 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489674 [I][Elf] Total size of loaded sections: 636
+489677 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489732 [I][Elf] Total size of loaded sections: 1024
+489735 [D][Fap] Library for NfcSupportedCardPlugin, API v. 1 loaded
+489740 [D][NfcSupportedCards] Loaded 22 plugins
+489744 [D][ViewDispatcher] View changed while key press 20029BE8 -> 2002
+489753 [D][MfClassicPoller] 4K detected
+
+[CRASH][NfcWorker] out of memory
+        r0 : 0
+        r1 : 0
+        r2 : 20000140
+        r3 : 809f711
+        r4 : 1040
+        r5 : 0
+        r6 : 0
+        r7 : 1038
+        r8 : a5a5a5a5
+        r9 : 0
+        r10 : 0
+        r11 : 20031364
+        lr : 801470b
+        stack watermark: 7632
+             heap total: 190144
+              heap free: 8944
+         heap watermark: 2952
+        core2: not faulted
+Rebooting system0 [I][FuriHalRtc] Init OK
+```
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04250-add-ability-to-verify-written-tags-buttons.md
+++ b/.ai/upstream-issues/04250-add-ability-to-verify-written-tags-buttons.md
@@ -1,0 +1,23 @@
+# Issue #4250: Add ability to verify written tags/buttons
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4250](https://github.com/flipperdevices/flipperzero-firmware/issues/4250)
+**Author:** @eblis
+**Created:** 2025-07-17T13:39:03Z
+**Labels:** Feature Request
+
+## Description
+
+### Description of the feature you're suggesting.
+
+Would it be possible to add a new menu entry for all modes of operation to allow verifications of IDs (written data)? 
+
+Or maybe for saved entries, have a new menu option to verify ID/data and it would verify that the selected entry has the same data as the RFID,iButton, NFC card(s) being read. 
+
+You basically select a saved entry and then you have a new menu called "Verify" which let's you verify the data with the original tag/card or you can use it to verify that the card you've just written is valid .. or if you have multiple cards and you don't know which is which you can use this to quickly find a specific tag/card.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04253-adding-a-js-command-to-directly-exit-the-applicati.md
+++ b/.ai/upstream-issues/04253-adding-a-js-command-to-directly-exit-the-applicati.md
@@ -1,0 +1,20 @@
+# Issue #4253: Adding a JS command to directly exit the application
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4253](https://github.com/flipperdevices/flipperzero-firmware/issues/4253)
+**Author:** @Zakrzewiaczek
+**Created:** 2025-07-27T07:40:11Z
+**Labels:** Feature Request, JS
+
+## Description
+
+### Description of the feature you're suggesting.
+
+
+I think a nice option would be to add a command that directly exits the JS application. Currently, after completing a script, we go to the console view, and to exit it, we have to press Back. The new command could directly exit to the application menu (bypassing the console view).
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04258-internal-gdb-error-when-trying-to-flash-firmware-u.md
+++ b/.ai/upstream-issues/04258-internal-gdb-error-when-trying-to-flash-firmware-u.md
@@ -1,0 +1,109 @@
+# Issue #4258: Internal GDB error when trying to flash firmware using wifi devboard
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4258](https://github.com/flipperdevices/flipperzero-firmware/issues/4258)
+**Author:** @MatthewTromp
+**Created:** 2025-07-31T17:59:50Z
+**Labels:** Triage
+
+## Description
+
+### Describe the bug.
+
+I'm trying to use the devboard to debug an application, following this guide: https://developer.flipper.net/flipperzero/doxygen/dev_board_debugging_guide.html
+With the devboard plugged in via usb (and itself plugged into the flipper zero of course), when running `./fbt flash`, I get an error, the screen on my flipper zero freezes and then goes dark and won't turn back on. I have to put it into firmware recovery mode to get it back. Here's the error:
+```
+sbaugh@moon:~/src/flipperzero-firmware$ ./fbt flash
+	SDKCHK	targets/f7/api_symbols.csv
+API version 86.0 is up to date
+python3 scripts/fwflash.py --interface=auto --serial=auto build/f7-firmware-D/firmware.elf
+2025-07-31 13:44:39,230 [INFO] Probing for local interfaces...
+2025-07-31 13:44:39,309 [INFO] Using blackmagic_usb
+2025-07-31 13:44:39,309 [INFO] Flashing /home/sbaugh/src/flipperzero-firmware/build/f7-firmware-D/firmware.elf
+......
+2025-07-31 13:44:40,811 [ERROR] Blackmagic failed to flash
+2025-07-31 13:44:40,812 [ERROR] GNU gdb (GDB) 13.2
+Copyright (C) 2023 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+Type "show copying" and "show warranty" for details.
+This GDB was configured as "--host=x86_64-pc-linux-gnu --target=arm-none-eabi".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<https://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+    <http://www.gnu.org/software/gdb/documentation/>.
+
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from /home/sbaugh/src/flipperzero-firmware/build/f7-firmware-D/firmware.elf...
+Remote debugging using /dev/ttyACM0
+Available Targets:
+No. Att Driver
+ 1      STM32WBxx M4
+Attaching to program: /home/sbaugh/src/flipperzero-firmware/build/f7-firmware-D/firmware.elf, Remote target
+/toolchain/src/src/gdb-13.2/gdb/thread.c:85: internal-error: inferior_thread: Assertion `current_thread_ != nullptr' failed.
+A problem internal to GDB has been detected,
+further debugging may prove unreliable.
+----- Backtrace -----
+0x604d847e4151 ???
+0x604d84b227b4 ???
+0x604d84b22a7a ???
+0x604d84c352b1 ???
+0x604d84ada35b ???
+0x604d84adab12 ???
+0x604d849ce9e9 ???
+0x604d849812cd ???
+0x604d84adf23e ???
+0x604d84a34c85 ???
+0x604d84a4c257 ???
+0x604d84960da3 ???
+0x604d84817204 ???
+0x604d84ae5dab ???
+0x604d849abf95 ???
+0x604d849ac061 ???
+0x604d849ad644 ???
+0x604d849ae13a ???
+0x604d8471fceb ???
+0x7fc53062a1c9 __libc_start_call_main
+	../sysdeps/nptl/libc_start_call_main.h:58
+0x7fc53062a28a __libc_start_main_impl
+	../csu/libc-start.c:360
+0x604d84726769 ???
+0xffffffffffffffff ???
+---------------------
+
+This is a bug, please report it.  For instructions, see:
+<https://www.gnu.org/software/gdb/bugs/>.
+2025-07-31 13:44:40,812 [ERROR] Failed to flash via blackmagic_usb
+scons: *** [build/flash.flag] Error 1
+
+********** FBT ERRORS **********
+build/flash.flag: Error 1
+```
+My wifi devboard's LED is currently red. It was originally blue, but I couldn't get it to do anything so I held the boot button for 10 seconds and the led changed to red and hasn't changed back since. I don't know the significance of this.
+
+### Reproduction
+
+1. Acquire a fresh wifi devboard
+2. Plug it into your computer via USB and hold the boot button for 10 seconds until the LED switches from blue to red
+3. Plug the devboard into your flipper zero
+4. Follow the steps here: https://developer.flipper.net/flipperzero/doxygen/dev_board_debugging_guide.html, selecting "Attach FW (blackmagic)" in step 4 of "Debugging the firmware", until step 5 of that section
+5. Run `./fbt flash` and note the error
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04262-error-while-building-firmware.md
+++ b/.ai/upstream-issues/04262-error-while-building-firmware.md
@@ -1,0 +1,82 @@
+# Issue #4262: Error while building firmware
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4262](https://github.com/flipperdevices/flipperzero-firmware/issues/4262)
+**Author:** @Rel0s
+**Created:** 2025-08-13T14:34:22Z
+**Labels:** Triage
+
+## Description
+
+Hi all,
+
+I am trying to build an updater package using fbt, and it results to the following error:
+
+  File "C:\Users\PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\assets\coprobin.py", line 117, in __init__
+    raise CoproException(f"Invalid FUS img magic {self.magic:x}")
+flipper.assets.coprobin.CoproException: Invalid FUS img magic a0d6f4e
+scons: *** [dist_updater_package] Error 1
+
+********** FBT ERRORS **********
+dist_updater_package: Error 1
+
+Steps that I took: 
+1. Install latest Git version.
+2. Updated qflipper windows app
+3. run git clone --recursive
+4.  run cmd as admin and running fbt COMPACT=1 DEBUG=0 updater_package
+5. The error appears
+
+In addition there is no errors with just running fbt command in the root folder.
+
+I have also tried the fbtenv in the scripts folder (same result).
+
+Full output:
+
+        DIST    dist_updater_package
+2025-08-13 17:26:59,657 [INFO] Firmware binaries can be found at:
+        dist\f7-C
+Traceback (most recent call last):
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\sconsdist.py", line 283, in <module>
+    Main()()
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\app.py", line 41, in __call__
+    return_code = self.call()
+                  ^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\app.py", line 57, in call
+    return self.args.func()
+           ^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\sconsdist.py", line 145, in copy
+    if bundle_result := self.bundle_update_package():
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\sconsdist.py", line 254, in bundle_update_package
+    if (bundle_result := UpdateMain(no_exit=True)(bundle_args)) == 0:
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\app.py", line 41, in __call__
+    return_code = self.call()
+                  ^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\app.py", line 57, in call
+    return self.args.func()
+           ^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\update.py", line 107, in generate
+    radio_meta = CoproBinary(self.args.radiobin)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\assets\coprobin.py", line 136, in __init__
+    self._load()
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\assets\coprobin.py", line 144, in _load
+    self.img_sig_footer = CoproSigFooter(img_sig_footer_bin)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware\scripts\flipper\assets\coprobin.py", line 117, in __init__
+    raise CoproException(f"Invalid FUS img magic {self.magic:x}")
+flipper.assets.coprobin.CoproException: Invalid FUS img magic a0d6f4e
+scons: *** [dist_updater_package] Error 1
+
+********** FBT ERRORS **********
+dist_updater_package: Error 1
+
+(fbt) C:\Users\Home PC\Desktop\flipper_OFW\flipperzero-firmware>
+
+
+
+
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04263-weather-station--support-for-lacrosse-tx141-bv3.md
+++ b/.ai/upstream-issues/04263-weather-station--support-for-lacrosse-tx141-bv3.md
@@ -1,0 +1,21 @@
+# Issue #4263: Weather station: support for LaCrosse TX141-BV3
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4263](https://github.com/flipperdevices/flipperzero-firmware/issues/4263)
+**Author:** @onepointfive-REAL
+**Created:** 2025-08-13T15:59:43Z
+**Labels:** Feature Request, Sub-GHz
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Add weather station support for LaCrosse TX141-BV3
+
+### Anything else?
+
+FCC ID: OMOTX141V3
+Operates on 433.92 mhz
+If you need more info i'd be happy to provide some more
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04269-support-non-standard-indala-rfid-fob.md
+++ b/.ai/upstream-issues/04269-support-non-standard-indala-rfid-fob.md
@@ -1,0 +1,23 @@
+# Issue #4269: Support non-standard Indala RFID fob
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4269](https://github.com/flipperdevices/flipperzero-firmware/issues/4269)
+**Author:** @asportnoy
+**Created:** 2025-08-28T03:23:48Z
+**Labels:** RFID 125kHz, Triage
+
+## Description
+
+### Description of the feature you're suggesting.
+
+I have an RFID keyfob that currently cannot be read by Flipper. I am >95% sure it is an Indala fob ([discussed in Discord](https://discord.com/channels/740930220399525928/954422698879098990/1408671165081325634) and that is the consensus) but I'm guessing it's a non-26 byte length since it doesn't seem to be supported. Beyond that, I don't know what byte length it actually is.
+
+### Anything else?
+
+Raw RFID dump: [Raw Data.zip](https://github.com/user-attachments/files/22016868/Raw.Data.zip) (had to zip it due to GH file type restrictions)
+
+Happy to give any additional information if this is not sufficient.
+
+Possibly related to #3046 or #1206
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04272-при-попытке-подключить-модуль-flipper-в-js-скрип.md
+++ b/.ai/upstream-issues/04272-при-попытке-подключить-модуль-flipper-в-js-скрип.md
@@ -1,0 +1,61 @@
+# Issue #4272: При попытке подключить модуль "flipper" в js-скрипте ошибка
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4272](https://github.com/flipperdevices/flipperzero-firmware/issues/4272)
+**Author:** @arduinotech
+**Created:** 2025-09-09T21:51:38Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+Пришу js-скрипт используя SDK (ts-файл).
+
+```typescript
+import * as flipper from "@flipperdevices/fz-sdk/flipper";
+print(flipper.getName())
+``` 
+
+Получаю ошибку:
+---- ERROR ----
+"flipper" module load fail
+Trace:
+        at /ext/apps/Scripts/multitool_flipper_zero_js.js:7
+
+Файл после конвертирование из ts в js:
+```javascript
+checkSdkCompatibility(0, 1);
+let exports = {};
+"use strict";
+
+// dist/index.js
+Object.defineProperty(exports, "__esModule", { value: true });
+var flipper = require("@flipperdevices/fz-sdk/flipper");
+print(flipper.getName());
+``` 
+
+Остальные модули импортируются и все работает корректно.
+Что может быть не так?
+
+### Reproduction
+
+1. Импортирую модуль "flipper"
+2. Запускаю скрипт через npm start
+3. Получаю ошибку
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04275-rfid-pet-animal.md
+++ b/.ai/upstream-issues/04275-rfid-pet-animal.md
@@ -1,0 +1,25 @@
+# Issue #4275: RFID Pet-animal
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4275](https://github.com/flipperdevices/flipperzero-firmware/issues/4275)
+**Author:** @MSmit715
+**Created:** 2025-09-12T11:06:40Z
+**Labels:** RFID 125kHz, Triage
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+I am trying to read an lf rfid chip, but i only get raw reads, no rfid reads, could you take a look at this one?
+
+[Dobby.ask.txt](https://github.com/user-attachments/files/22296550/Dobby.ask.txt)
+
+[Dobby.psk.txt](https://github.com/user-attachments/files/22296563/Dobby.psk.txt)
+
+these were raw files which i changed to txt files, i dont know if this is the correct way.
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04276-rfid-keyfob.md
+++ b/.ai/upstream-issues/04276-rfid-keyfob.md
@@ -1,0 +1,28 @@
+# Issue #4276: RFID keyfob
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4276](https://github.com/flipperdevices/flipperzero-firmware/issues/4276)
+**Author:** @MSmit715
+**Created:** 2025-09-12T11:10:39Z
+**Labels:** RFID 125kHz, Triage
+
+## Description
+
+### Describe the enhancement you're suggesting.
+
+Hi,
+I am trying to get a read from a keyfob, but it doesnt read, only raw file.
+Could you take a look?
+
+[RfidRecord.ask.txt](https://github.com/user-attachments/files/22296602/RfidRecord.ask.txt)
+[RfidRecord.psk.txt](https://github.com/user-attachments/files/22296601/RfidRecord.psk.txt)
+
+I changed the .raw file to .txt, i dont know if this is the correct way.
+
+KR Martijn
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04281-mbedtls-add-ecdh.md
+++ b/.ai/upstream-issues/04281-mbedtls-add-ecdh.md
@@ -1,0 +1,21 @@
+# Issue #4281: [mbedtls] Add ECDH
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4281](https://github.com/flipperdevices/flipperzero-firmware/issues/4281)
+**Author:** @bettse
+**Created:** 2025-10-02T00:05:30Z
+**Labels:** Feature Request, Core+Services
+
+## Description
+
+### Description of the feature you're suggesting.
+
+This is like https://github.com/flipperdevices/flipperzero-firmware/issues/4009
+
+I'd love it if the ECDH part of the mbedtls library were exposed.  This would allow PACE eMTRD(passport) support, and the ability to talk to PIV credentials
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04289-same-bag-as-cards-2218.md
+++ b/.ai/upstream-issues/04289-same-bag-as-cards-2218.md
@@ -1,0 +1,33 @@
+# Issue #4289: Same bag as cards #2218
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4289](https://github.com/flipperdevices/flipperzero-firmware/issues/4289)
+**Author:** @fishboW1
+**Created:** 2025-10-05T01:30:50Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+It is not question of flipper , but it same as cards #2218 i,ve  to write em4100 on em4305 by chinese reader "whited color type from ali, you know what i mean" so in process this device take double time while writing and gave "write failure" after i,ve tried to read em4305 but it was "read failure". Have you idea why? 
+
+### Reproduction
+
+"whited color type from ali, you know what i mean" so in process this device take double time while writing and gave "write failure" after i,ve tried to read em4305 but it was "read failure". Have you idea why
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04300-nfc-app-refuses-to-write-ndef-after-tag-was-passwo.md
+++ b/.ai/upstream-issues/04300-nfc-app-refuses-to-write-ndef-after-tag-was-passwo.md
@@ -1,0 +1,152 @@
+# Issue #4300: NFC app refuses to write NDEF after tag was password-protected, misinterprets AUTH0 / lock bytes for NTAG21x (tested on genuine NTAG216)
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4300](https://github.com/flipperdevices/flipperzero-firmware/issues/4300)
+**Author:** @TomHarkness
+**Created:** 2025-10-27T03:58:22Z
+**Labels:** None
+
+## Description
+
+**Firmware:** Momentum & latest Official (latest build as of Oct 2025)  
+**App:** Flipper NFC → NTAG21x / Advanced → Write / Read / Detect  
+**Hardware tested:**  
+- Genuine NXP NTAG216  
+- Dangerous Things NExT implant (NTAG216 core)  
+
+### Summary
+
+After setting a password on a genuine NTAG216 or NExT implant (using standard NXP authentication scheme), Flipper detects the tag as "password protected" **even after the password is cleared and the tag is reset to default (AUTH0=FF)**.
+
+Other NFC apps (e.g. NFC Tools, TagInfo) correctly detect the tag as **unprotected** and can read/write NDEF data normally.
+
+The issue appears to be that Flipper’s NFC app incorrectly interprets bits in the **AUTH0** or **lock byte pages (0x28–0x2B)** as indicating password protection when it should not.
+
+### Hypothesis
+
+Flipper NFC’s NTAG21x detection logic likely interprets:
+- `AUTH0` incorrectly (checking for non-`0xFF` or reserved bits)
+- or `ACCESS` / `LOCK` bytes as indicating protection even when cleared.
+
+The NTAG216 spec defines:
+- `AUTH0 = 0xFF` → **no protection**
+- `ACCESS` bits define protection granularity but do not indicate password presence directly.
+
+Flipper might be reading stale or misaligned config bytes
+
+
+### Reproduction
+
+## Reproducible command sets (raw Type-2 frames)
+
+> Use these command blocks in NFC Tools → Advanced → Raw / Advanced Commands (each comma-separated string is one run/sequence). They are the exact sequences we used to reproduce.
+
+### 1) Check for a password / protection (diagnostic)
+3029,302B,302A,3003,1B4E457854
+
+**What this does**
+- `3029` — READ page `0x29` (contains AUTH0; byte 3 = AUTH0). If AUTH0 != `FF` protection begins at that page.  
+- `302B` — READ page `0x2B` (PWD page). Shows the 4-byte PWD if present.  
+- `302A` — READ page `0x2A` (ACCESS byte + flags). Bit flags here (PROT, AUTHLIM, etc.) affect password behaviour.  
+- `3003` — READ page `0x03` (Capability Container / CC) to confirm NDEF presence and memory sizing.  
+- `1B4E457854` — PWD_AUTH using the lowercase `NExT` password (`4E 45 78 54`). If authentication succeeds the tag returns PACK (2 bytes). This proves whether `NExT` is accepted.
+
+---
+
+### 2) Set password to `NExT` and protect configuration pages only (leave user/NDEF area writable)
+3029,302B,1B4E457854,A22B4E457854,A22CA55A0000,A22900002B00,1B4E457854,3029,302B
+
+**What this does**
+- `3029,302B` — Read current config & PWD pages (safety check).  
+- `1B4E457854` — Attempt auth with `NExT` (safe; NAK if not set). If tag already protected it lets you proceed.  
+- `A22B4E457854` — WRITE page `0x2B` = `4E 45 78 54` (set PWD = `NExT`).  
+- `A22CA55A0000` — WRITE page `0x2C` = `A5 5A 00 00` (set PACK = `A5 5A`, padding zeroes).  
+- `A22900002B00` — WRITE page `0x29` = `00 00 2B 00` (set `AUTH0 = 0x2B` so protection starts at page `0x2B` — this protects config pages but keeps NDEF/user memory writable).  
+- `1B4E457854` — Authenticate again to verify the password returns PACK.  
+- `3029,302B` — Read back `0x29` / `0x2B` to confirm changes.
+
+---
+
+### 3) Clear password and return tag to default/unprotected state
+1B4E457854,A22B00000000,A22C00000000,A2290000FF00,3029,302B,3003,3004
+
+**What this does**
+- `1B4E457854` — Authenticate with current password `NExT` (required if config pages are currently protected).  
+- `A22B00000000` — WRITE page `0x2B` = `00 00 00 00` (clear PWD).  
+- `A22C00000000` — WRITE page `0x2C` = `00 00 00 00` (clear PACK).  
+- `A2290000FF00` — WRITE page `0x29` = `00 00 FF 00` (set `AUTH0 = 0xFF` which disables password protection).  
+- `3029,302B` — Read back `0x29` and `0x2B` to verify `AUTH0 = FF` and PWD cleared.  
+- `3003,3004` — Read CC and first NDEF page to confirm the user memory and TLV are intact and writable.
+
+---
+
+## Observed vs expected behaviour
+
+**Observed**
+- After running the “clear password” block, `3029` shows `AUTH0 = 0xFF`, `302A` shows `ACCESS = 0x00`, and `302B`/`302C` show zeros — tag is unprotected and writable by phone tools.  
+- Flipper NFC helper still reports “card protected by password AUTH0 or lock bits” and refuses to write saved NDEF via the helper. Raw page writes via Flipper CLI/UI may succeed, indicating the helper (not the hardware) is making the decision to abort.
+
+**Expected**
+- When `AUTH0 == 0xFF` and `ACCESS == 0x00` and `PWD/PACK` cleared, Flipper should treat the tag as unprotected and allow NDEF writes via the NFC helper.
+
+---
+
+## Suggested fixes for Flipper NFC app
+
+1. **Correct AUTH0 interpretation** — treat `AUTH0 == 0xFF` as unprotected and allow writes. Do not conservatively block writes just because lock bytes are nonzero unless CFGLCK/permanent lock bits indicate irreversible config lock.  
+2. **Distinguish permanent vs non-permanent lock bits** — interpret page `0x02` lock bytes according to the NTAG datasheet; only treat CFGLCK/irreversible bits as absolute blockers.  
+3. **Prompt for PWD_AUTH when required** — if `AUTH0 <= first NDEF page` or `ACCESS` indicates protection that will affect the operation, prompt the user to supply a password and attempt `PWD_AUTH` rather than failing immediately.  
+4. **Add an “Advanced/Force write (unsafe)” option** to allow expert users to bypass the helper checks (with clear warnings).  
+5. **Always re-read config immediately before a write** — do not rely on cached/paranoid heuristics from earlier reads.
+
+### 🧾 References
+
+- [NXP NTAG213/215/216 Data Sheet — Section 8.8.2 AUTH0 definition](https://www.nxp.com/docs/en/data-sheet/NTAG213_215_216.pdf)
+- [Dangerous Things NExT Documentation](https://dangerousthings.com/product/next/)
+
+### Logs
+
+```Text
+## Commands & tag dumps (exact used during testing)
+
+### Auth succeeded with `NExT`
+1B4E457854
+<< 00 00
+
+---
+
+### After clearing & setting `AUTH0 = FF`
+A2 29 00 00 FF 00
+<< 0A
+
+30 29
+<< 00 00 FF 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+30 2B
+<< 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0
+
+---
+
+### CC and NDEF TLV
+30 03
+<< E1 10 6D 00 03 0B D1 01 07 54 02 65 6E 54 65 73
+
+30 04
+<< 03 0B D1 01 07 54 02 65 6E 54 65 73 74 FE 00 00
+
+---
+
+### UID and lock bytes
+30 00
+<< 04 A7 6E 45
+
+30 01
+<< 1A BD 39 80
+
+30 02
+<< 1E 48 00 00 // lock/OTP area (non-zero; normal for many tags)
+
+
+> **Note:** tag is a genuine NXP NTAG216 sticker used for testing. Hu
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04303-freezing-desktop-animation.md
+++ b/.ai/upstream-issues/04303-freezing-desktop-animation.md
@@ -1,0 +1,43 @@
+# Issue #4303: Freezing desktop animation
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4303](https://github.com/flipperdevices/flipperzero-firmware/issues/4303)
+**Author:** @Crudefern
+**Created:** 2025-10-30T03:07:55Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+exactly what it says, the animation freezes on the first frame
+doing things like opening and exiting an app un-freezes it but it will happen again if you repeat the steps
+...the issue's so simple i'm not exactly sure what else to write other than it happens on 1.3.4, RC 1.4.0, and the latest commit (468cc45f)
+
+
+### Reproduction
+
+1. switch on
+2. press left to open the apps menu
+3. press back without launching anything
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+#sitting on the desktop after a reboot, about to press left
+7959 [I][AnimationManager] Unload animation 'L1_Doom_128x64'
+7976 [D][BrowserWorker] Start
+7996 [D][BrowserWorker] Enter folder: /ext/apps items: 11 idx: -1
+7998 [D][BrowserWorker] Load offset: 0 cnt: 50
+9140 [D][BrowserWorker] End #this is the only line that appears when exiting the menu
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04307-how-to-use-sub-ghz.md
+++ b/.ai/upstream-issues/04307-how-to-use-sub-ghz.md
@@ -1,0 +1,13 @@
+# Issue #4307: How to use sub-GHz
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4307](https://github.com/flipperdevices/flipperzero-firmware/issues/4307)
+**Author:** @Inkpro436
+**Created:** 2025-11-08T20:58:51Z
+**Labels:** None
+
+## Description
+
+It's interesting
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04310-incorrect-sub-ghz-region-lock-for-bh-bahrain--4.md
+++ b/.ai/upstream-issues/04310-incorrect-sub-ghz-region-lock-for-bh-bahrain--4.md
@@ -1,0 +1,26 @@
+# Issue #4310: Incorrect Sub-GHz region lock for BH (Bahrain) — 433 MHz should be permitted
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4310](https://github.com/flipperdevices/flipperzero-firmware/issues/4310)
+**Author:** @el7ommed
+**Created:** 2025-11-20T07:12:34Z
+**Labels:** None
+
+## Description
+
+When the Flipper Zero is provisioned in Bahrain (country code BH), Sub-GHz transmissions on 433.92 MHz AM/OOK are blocked, even though this band is legal for low-power SRD devices in Bahrain.
+
+How to reproduce:
+• Device is provisioned as BH through the iOS app
+• Record a 433.92 MHz AM remote signal
+• Attempt to transmit → Flipper shows: Transmission is Blocked!
+
+Local laws allow the use of these frequencies as per the pdf file below:
+PDF : https://www.bahrain.bh/wps/wcm/connect/55803dc3-cae2-4859-9f6d-ce3898df840e/National+Frequency+Plan+2020.pdf?MOD=AJPERES&CVID=njzfrwX
+Relevant section: Table at page 47 → “AMATEUR BHR2 - up to 25W”.
+
+
+What should happen:
+The BH region should allow transmissions within 433.05–434.79 MHz, same as EU-style SRD allocations.
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04314-reading-saved-felica-standart-emulation-by-another.md
+++ b/.ai/upstream-issues/04314-reading-saved-felica-standart-emulation-by-another.md
@@ -1,0 +1,108 @@
+# Issue #4314: Reading saved Felica Standart emulation by another FZ leads to its crash
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4314](https://github.com/flipperdevices/flipperzero-firmware/issues/4314)
+**Author:** @RebornedBrain
+**Created:** 2025-12-01T08:57:40Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+@zinongli There is a problem with new Felica Standard emulation/reading. See reproducion steps below. Issue happens here because system_total equals 0.
+
+<img width="1545" height="1144" alt="Image" src="https://github.com/user-attachments/assets/624091b8-0d2f-43c8-a1f7-348c562ae83d" />
+
+Looks like the roots of this issue are from doing load/save operations a little bit incorrectly. In those `felica_load` and `felica_save` functions there are bool flags `parsed` and `saved` respectively, which indicates the result of the operation. Newly added logic doesn't modify them. Let's take as an example `felica_load` function, there we have this check in red square which checks that everything before it was parsed fine, otherwise we exit with false. If everything is fine we continue and `parsed` is true, but what if we fail to read smth in code below? We also need to set that flag correctly.
+
+<img width="1589" height="1167" alt="Image" src="https://github.com/user-attachments/assets/eb7d398b-667a-4401-9685-f5397d8f2152" />
+
+And how issue happens, we start to read empy dump where there is no services for example, we reach this part and exit, but return parsed = true, while in fact we didn't complete reading and need to return false, for logic to work correctly.
+
+<img width="1653" height="890" alt="Image" src="https://github.com/user-attachments/assets/f85f6251-fc41-4ddc-8a10-4d834945c738" />
+
+Also I want to warn that fixing this issue by simply adding `parsed = false` to each break will not work (I've already tried 😿) because it will lead to another issue that completely fine blank Felica Standard cards will fail to open for emulation on FZ. 
+
+Maybe some more checks about blank parts of Felica Standard could help, as an idea if we read count == 0, then we skip simple_array_init, or smth like that.
+
+
+
+### Reproduction
+
+1. You need two Flipper Zeros flashed with latest 1.4.2 release
+2. Read empty Felica Standart card with one Flipper and save it.
+3. Open new saved card and start emulation
+4. Take another Flipper and try to read emulation.
+Result: Flipper which performs reading crashes and reboot is needed to bring it back
+
+### Target
+
+1.4.2
+
+### Logs
+
+```Text
+556561 [I][AnimationManager] Unload animation 'L2_Wake_up_128x64'
+556575 [I][Loader] Loading /ext/apps/NFC/nfc.fap
+556761 [I][Elf] Total size of loaded sections: 81253
+556764 [I][Loader] Loaded in 189ms
+574308 [I][NfcScanner] Detected 1 protocols
+574417 [W][ViewPort] ViewPort lockup: see applications/services/gui/view_port.c:                           245
+574483 [I][Elf] Total size of loaded sections: 9036
+574530 [I][Elf] Total size of loaded sections: 888
+574575 [I][Elf] Total size of loaded sections: 420
+574625 [I][Elf] Total size of loaded sections: 2296
+574675 [I][Elf] Total size of loaded sections: 1804
+574742 [I][Elf] Total size of loaded sections: 3212
+574804 [I][Elf] Total size of loaded sections: 4892
+574851 [I][Elf] Total size of loaded sections: 284
+574905 [I][Elf] Total size of loaded sections: 1356
+574953 [I][Elf] Total size of loaded sections: 820
+575003 [I][Elf] Total size of loaded sections: 1844
+575056 [I][Elf] Total size of loaded sections: 548
+575109 [I][Elf] Total size of loaded sections: 1396
+575165 [I][Elf] Total size of loaded sections: 1608
+575215 [I][Elf] Total size of loaded sections: 908
+575273 [I][Elf] Total size of loaded sections: 1212
+575330 [I][Elf] Total size of loaded sections: 5068
+575392 [I][Elf] Total size of loaded sections: 4624
+575449 [I][Elf] Total size of loaded sections: 4616
+575500 [I][Elf] Total size of loaded sections: 1324
+575553 [I][Elf] Total size of loaded sections: 3276
+575604 [I][Elf] Total size of loaded sections: 1144
+575682 [I][Elf] Total size of loaded sections: 9532
+575752 [I][Elf] Total size of loaded sections: 1956
+575802 [I][Elf] Total size of loaded sections: 368
+575854 [I][Elf] Total size of loaded sections: 1464
+575906 [I][Elf] Total size of loaded sections: 636
+575959 [I][Elf] Total size of loaded sections: 1024
+576006 [E][FelicaPoller] Request system code failed with error: 8
+
+[CRASH][NfcWorker] furi_check failed
+        r0 : 2000d2f8
+        r1 : 0
+        r2 : 20000140
+        r3 : 2000d0d8
+        r4 : 2000d2f8
+        r5 : 0
+        r6 : a5a5a5a5
+        r7 : a5a5a5a5
+        r8 : a5a5a5a5
+        r9 : a5a5a5a5
+        r10 : a5a5a5a5
+        r11 : 20031364
+        lr : 80378c9
+        stack watermark: 7640
+             heap total: 190144
+              heap free: 42712
+         heap watermark: 29624
+        core2: not faulted
+System halted. Connect debugger for more info
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04317-system-protobuf-version-timeout.md
+++ b/.ai/upstream-issues/04317-system-protobuf-version-timeout.md
@@ -1,0 +1,47 @@
+# Issue #4317: "System Protobuf Version timeout"
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4317](https://github.com/flipperdevices/flipperzero-firmware/issues/4317)
+**Author:** @zatcx
+**Created:** 2025-12-18T09:59:36Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+I have a brand new Flipper Zero that cannot be updated or repaired.
+
+- qFlipper always fails with: "System Protobuf Version timeout"
+- The device cannot enter DFU / bootloader mode with any key combination
+- Device always boots into normal OS (sleep screen)
+- Android app can connect via Bluetooth, but device data never loads (empty screen)
+- Firmware update via mobile app is not possible
+- USB update / repair is not possible
+
+I have tried all documented recovery methods.
+Logs are available.
+
+Requesting recovery instructions or RMA.
+
+
+
+### Reproduction
+
+I dont know
+
+### Target
+
+_No response_
+
+### Logs
+
+```Text
+
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04321-ntag215-emulation-enables-password-auth-and-config.md
+++ b/.ai/upstream-issues/04321-ntag215-emulation-enables-password-auth-and-config.md
@@ -1,0 +1,145 @@
+# Issue #4321: NTAG215 emulation enables password auth and config lock too early
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4321](https://github.com/flipperdevices/flipperzero-firmware/issues/4321)
+**Author:** @Firefox2100
+**Created:** 2025-12-25T14:25:16Z
+**Labels:** None
+
+## Description
+
+### Describe the bug.
+
+In a proper NTAG215 tag, when it first shipped with AUTH0 not configured and the write start, it's in `ACTIVE` state, and all pages are not protected. Later once the password and AUTH0 is written into, without an explict HLTA or power cycle, the tag stays in `ACTIVE` state and does not require password to write to protected pages. See below in the logs for a trace of mobile application Ally performing write on an NTAG215.
+
+After writing the block 134 and 133, AUTH0 is set to protect anything beyond block 4 with write to 131, then with no PWD-AUTH, the write to 132 succeeded, showing that the tag does not immediately require authentication when AUTH0 is configured within the same session.
+
+However on Flipper Zero, this is immediate -- password auth is required immediately after writing to 131, causing the next write to 132 to NAK without PWD-AUTH. This creates a discrepency between real NTAG215 and Flipper emulation. Similarly, the CFGLCK is also enabled immediately after writing, while the datasheet explictly states that the CFGLCK will only be enabled after a power cycle.
+
+### Reproduction
+
+1. Load an NFC file for an empty NTAG215
+2. Enable emulation
+3. Trying to write into it with a tool that does the aforementioned sequence, for example TagMo or Ally
+4. Tool returns an error. Sniffing with PM3 confirms that the write to page 132 gets NAK. Going through the code there's no delayed activation of password auth or CFGLCK.
+
+### Target
+
+NFC emulation
+
+### Logs
+
+```Text
+Ally writing to NTAG215
+
+
+      Start |        End | Src | Data (! denotes parity error)                                           | CRC | Annotation
+------------+------------+-----+-------------------------------------------------------------------------+-----+--------------------
+          0 |       1056 | Rdr |26(7)                                                                    |     | REQA
+       2244 |       4612 | Tag |44  00                                                                   |     | 
+      11776 |      16544 | Rdr |50  00  57  cd                                                           |  ok | HALT
+      39072 |      40064 | Rdr |52(7)                                                                    |     | WUPA
+      41316 |      43684 | Tag |44  00                                                                   |     | 
+      50848 |      53312 | Rdr |93  20                                                                   |     | ANTICOLL
+      54500 |      60324 | Tag |88  04  e2  0b  65                                                       |     | 
+      67504 |      77968 | Rdr |93  70  88  04  e2  0b  65  1f  17                                       |  ok | SELECT_UID
+      79220 |      82740 | Tag |04  da  17                                                               |     | 
+      89904 |      92368 | Rdr |95  20                                                                   |     | ANTICOLL-2
+      93556 |      99444 | Tag |66  10  02  89  fd                                                       |     | 
+     106560 |     117088 | Rdr |95  70  66  10  02  89  fd  dd  1a                                       |  ok | SELECT_UID-2
+     118276 |     121860 | Tag |00  fe  51                                                               |     | 
+     264976 |     268592 | Rdr |60  f8  32                                                               |  ok | EV1 VERSION
+     269780 |     281428 | Tag |00  04  04  02  01  00  11  03  01  9e                                   |  ok | 
+     328544 |     333312 | Rdr |50  00  57  cd                                                           |  ok | HALT
+     473920 |     474912 | Rdr |52(7)                                                                    |     | WUPA
+     476164 |     478532 | Tag |44  00                                                                   |     | 
+     485696 |     496160 | Rdr |93  70  88  04  e2  0b  65  1f  17                                       |  ok | SELECT_UID
+     497412 |     500932 | Tag |04  da  17                                                               |     | 
+     508112 |     518640 | Rdr |95  70  66  10  02  89  fd  dd  1a                                       |  ok | SELECT_UID-2
+     519828 |     523412 | Tag |00  fe  51                                                               |     | 
+     617488 |     621104 | Rdr |55  d6  54                                                               |  ok | 
+    5804160 |    5805216 | Rdr |26(7)                                                                    |     | REQA
+    5806404 |    5808772 | Tag |44  00                                                                   |     | 
+    5815936 |    5820704 | Rdr |50  00  57  cd                                                           |  ok | HALT
+    5843232 |    5844224 | Rdr |52(7)                                                                    |     | WUPA
+    5845476 |    5847844 | Tag |44  00                                                                   |     | 
+    5855008 |    5857472 | Rdr |93  20                                                                   |     | ANTICOLL
+    5858660 |    5864484 | Tag |88  04  e2  0b  65                                                       |     | 
+    5871664 |    5882128 | Rdr |93  70  88  04  e2  0b  65  1f  17                                       |  ok | SELECT_UID
+    5883380 |    5886900 | Tag |04  da  17                                                               |     | 
+    5894064 |    5896528 | Rdr |95  20                                                                   |     | ANTICOLL-2
+    5897716 |    5903604 | Tag |66  10  02  89  fd                                                       |     | 
+    5910720 |    5921248 | Rdr |95  70  66  10  02  89  fd  dd  1a                                       |  ok | SELECT_UID-2
+    5922436 |    5926020 | Tag |00  fe  51                                                               |     | 
+    5981008 |    5984624 | Rdr |60  f8  32                                                               |  ok | EV1 VERSION
+    5985812 |    5997460 | Tag |00  04  04  02  01  00  11  03  01  9e                                   |  ok | 
+    6045760 |    6050528 | Rdr |50  00  57  cd                                                           |  ok | HALT
+    6140912 |    6141904 | Rdr |52(7)                                                                    |     | WUPA
+    6143156 |    6145524 | Tag |44  00                                                                   |     | 
+    6152704 |    6163168 | Rdr |93  70  88  04  e2  0b  65  1f  17                                       |  ok | SELECT_UID
+    6164420 |    6167940 | Tag |04  da  17                                                               |     | 
+    6175104 |    6185632 | Rdr |95  70  66  10  02  89  fd  dd  1a                                       |  ok | SELECT_UID-2
+    6186820 |    6190404 | Tag |00  fe  51                                                               |     | 
+    6249920 |    6253536 | Rdr |60  f8  32                                                               |  ok | EV1 VERSION
+    6254724 |    6266372 | Tag |00  04  04  02  01  00  11  03  01  9e                                   |  ok | 
+    6331984 |    6336752 | Rdr |3c  00  a2  01                                                           |  ok | READ SIG
+    6337940 |    6377236 | Tag |00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00   |     | 
+            |            |     |00  00  00  00  00  00  00  00  00  00  00  00  00  00  20  da           |  ok | 
+    6437840 |    6443760 | Rdr |3a  00  03  5b  62                                                       |  ok | READ RANGE (0-3)
+    6444948 |    6465812 | Tag |04  e2  0b  65  66  10  02  89  fd  48  00  00  e1  10  3e  00  e6  f4   |  ok | 
+    6536464 |    6540080 | Rdr |60  f8  32                                                               |  ok | EV1 VERSION
+    6541268 |    6552916 | Tag |00  04  04  02  01  00  11  03  01  9e                                   |  ok | 
+    6615104 |    6619872 | Rdr |3c  00  a2  01                                                           |  ok | READ SIG
+    6621060 |    6660356 | Tag |00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00   |     | 
+            |            |     |00  00  00  00  00  00  00  00  00  00  00  00  00  00  20  da           |  ok | 
+    6732768 |    6742080 | Rdr |a2  04  a5  00  0a  00  2d  a3                                           |  ok | WRITEBLOCK(4)
+    6795172 |    6795748 | Tag |0a(3)                                                                    |     | 
+    6860400 |    6869712 | Rdr |a2  05  a8  e1  08  b7  1f  82                                           |  ok | WRITEBLOCK(5)
+    6922804 |    6923380 | Tag |0a(3)                                                                    |     | 
+    6988320 |    6997632 | Rdr |a2  06  c8  da  08  49  ce  b7                                           |  ok | WRITEBLOCK(6)
+    7050724 |    7051300 | Tag |0a(3)                                                                    |     | 
+...
+   22456352 |   22465664 | Rdr |a2  80  da  7a  5e  3a  38  35                                           |  ok | WRITEBLOCK(128) (?)
+   22518756 |   22519332 | Tag |0a(3)                                                                    |     | 
+   22586224 |   22595600 | Rdr |a2  81  5c  da  e4  1e  67  f7                                           |  ok | WRITEBLOCK(129) (?)
+   22648628 |   22649204 | Tag |0a(3)                                                                    |     | 
+   22711312 |   22720688 | Rdr |a2  86  80  80  00  00  68  2f                                           |  ok | WRITEBLOCK(134) (?)
+   22773716 |   22774292 | Tag |0a(3)                                                                    |     | 
+   22840480 |   22849792 | Rdr |a2  85  2e  4e  ce  cc  80  78                                           |  ok | WRITEBLOCK(133) (?)
+   22902884 |   22903460 | Tag |0a(3)                                                                    |     | 
+   22964432 |   22973744 | Rdr |a2  03  f1  10  ff  ee  5e  bd                                           |  ok | WRITEBLOCK(3)
+   23026836 |   23027412 | Tag |0a(3)                                                                    |     | 
+   23093488 |   23102864 | Rdr |a2  83  00  00  00  04  9a  6e                                           |  ok | WRITEBLOCK(131) (?)
+   23155892 |   23156468 | Tag |0a(3)                                                                    |     | 
+   23222160 |   23231536 | Rdr |a2  84  5f  00  00  00  8d  7f                                           |  ok | WRITEBLOCK(132) (?)
+   23284564 |   23285140 | Tag |0a(3)                                                                    |     | 
+   23348512 |   23357824 | Rdr |a2  82  01  00  0f  bd  e7  d2                                           |  ok | WRITEBLOCK(130) (?)
+   23410916 |   23411492 | Tag |0a(3)                                                                    |     | 
+   23475344 |   23484720 | Rdr |a2  02  fd  48  0f  e0  79  f1                                           |  ok | WRITEBLOCK(2)
+   23537748 |   23538324 | Tag |0a(3)                                                                    |     | 
+   23605248 |   23610016 | Rdr |50  00  57  cd                                                           |  ok | HALT
+   63458960 |   63460016 | Rdr |26(7)                                                                    |     | REQA
+   63461204 |   63463572 | Tag |44  00                                                                   |     | 
+   63470736 |   63475504 | Rdr |50  00  57  cd                                                           |  ok | HALT
+   63498032 |   63499024 | Rdr |52(7)                                                                    |     | WUPA
+   63500276 |   63502644 | Tag |44  00                                                                   |     | 
+   63509808 |   63512272 | Rdr |93  20                                                                   |     | ANTICOLL
+   63513476 |   63519300 | Tag |88  04  e2  0b  65                                                       |     | 
+   63526464 |   63536928 | Rdr |93  70  88  04  e2  0b  65  1f  17                                       |  ok | SELECT_UID
+   63538180 |   63541700 | Tag |04  da  17                                                               |     | 
+   63548864 |   63551328 | Rdr |95  20                                                                   |     | ANTICOLL-2
+   63552532 |   63558420 | Tag |66  10  02  89  fd                                                       |     | 
+   63565520 |   63576048 | Rdr |95  70  66  10  02  89  fd  dd  1a                                       |  ok | SELECT_UID-2
+   63577236 |   63580820 | Tag |00  fe  51                                                               |     | 
+   63663280 |   63667984 | Rdr |30  02  10  8b                                                           |  ok | READBLOCK(2)
+   63721092 |   63741956 | Tag |fd  48  0f  e0  f1  10  ff  ee  a5  00  0a  00  a8  e1  08  b7  4f  67   |  ok | 
+   63937632 |   63938688 | Rdr |26(7)                                                                    |     | REQA
+   63939876 |   63942244 | Tag |44  00                                                                   |     | 
+   63949408 |   63954176 | Rdr |50  00  57  cd                                                           |  ok | HALT
+```
+
+### Anything else?
+
+_No response_
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/04322-javascript---infrared-module.md
+++ b/.ai/upstream-issues/04322-javascript---infrared-module.md
@@ -1,0 +1,21 @@
+# Issue #4322: Javascript - Infrared Module
+
+**Original Issue:** [https://github.com/flipperdevices/flipperzero-firmware/issues/4322](https://github.com/flipperdevices/flipperzero-firmware/issues/4322)
+**Author:** @LuisMayo
+**Created:** 2025-12-27T23:17:24Z
+**Labels:** None
+
+## Description
+
+### Description of the feature you're suggesting.
+
+This would be a new module for the JS engine that allows the script to send (maybe receive?) IR commands through the built-in infrared LED (/receiver)
+
+### Anything else?
+
+Not sure if it's out of scope (Sub-GHz isn't there either) but I haven't found if anybody filled this request earlier so here hoes nothing.
+
+Thank you for your work and really good documentation btw
+
+---
+*This issue was automatically imported from the upstream Flipper Zero firmware repository.*

--- a/.ai/upstream-issues/README.md
+++ b/.ai/upstream-issues/README.md
@@ -1,0 +1,705 @@
+# Upstream Issues Index
+
+**Total Issues:** 162
+**Last Updated:** 2025-12-30 07:45:11 UTC
+**Source:** [flipperdevices/flipperzero-firmware](https://github.com/flipperdevices/flipperzero-firmware)
+
+## Issues by Category
+
+
+### Applications (2 issues)
+
+- [#1038: Feature Request: i2c and SPI bridge to USB](https://github.com/flipperdevices/flipperzero-firmware/issues/1038)
+- [#3877: Less granular value selection in Bluetooth HID Mouse Clicker](https://github.com/flipperdevices/flipperzero-firmware/issues/3877)
+
+### Backlog (6 issues)
+
+- [#1656: Add badusb configs](https://github.com/flipperdevices/flipperzero-firmware/issues/1656)
+- [#1800: Remote Macros](https://github.com/flipperdevices/flipperzero-firmware/issues/1800)
+- [#1886: NFC st25ta support](https://github.com/flipperdevices/flipperzero-firmware/issues/1886)
+- [#2104: Change USB Vendor ID and Product ID to something non generic](https://github.com/flipperdevices/flipperzero-firmware/issues/2104)
+- [#2513: U2F over Bluetooth](https://github.com/flipperdevices/flipperzero-firmware/issues/2513)
+- [#4248: Inconsistent file path syntax in CLI](https://github.com/flipperdevices/flipperzero-firmware/issues/4248)
+
+### Bluetooth (7 issues)
+
+- [#2031: Don't attach the device name in all BLE advertising packages](https://github.com/flipperdevices/flipperzero-firmware/issues/2031)
+- [#2513: U2F over Bluetooth](https://github.com/flipperdevices/flipperzero-firmware/issues/2513)
+- [#3778: Support multiple devices for BT remote](https://github.com/flipperdevices/flipperzero-firmware/issues/3778)
+- [#4011: change Bluetooth / device name](https://github.com/flipperdevices/flipperzero-firmware/issues/4011)
+- [#4079: Export BLE buffers in SKD](https://github.com/flipperdevices/flipperzero-firmware/issues/4079)
+- [#4218: [Buetooth] Why is the extra beacon size limited to 31?](https://github.com/flipperdevices/flipperzero-firmware/issues/4218)
+- [#4247: NFC files not syncing via Bluetooth from Flipper to Android app (v1.8)](https://github.com/flipperdevices/flipperzero-firmware/issues/4247)
+
+### Bug (27 issues)
+
+- [#1468: NFC Emulation of previously saved Mifare classic 1k card does not work.](https://github.com/flipperdevices/flipperzero-firmware/issues/1468)
+- [#1847: iButton ds1990a emulation doesn't work](https://github.com/flipperdevices/flipperzero-firmware/issues/1847)
+- [#2562: Skylanders real-time write issue](https://github.com/flipperdevices/flipperzero-firmware/issues/2562)
+- [#2563: U2F does not work with some services](https://github.com/flipperdevices/flipperzero-firmware/issues/2563)
+- [#2596: Set minimum battery voltage](https://github.com/flipperdevices/flipperzero-firmware/issues/2596)
+- [#2609: Fix saving selected settings in Sub-GHz](https://github.com/flipperdevices/flipperzero-firmware/issues/2609)
+- [#2733: NexWatch/NexKey support added in .84 not working - will not read cards](https://github.com/flipperdevices/flipperzero-firmware/issues/2733)
+- [#2775: Mifare Plus golmar key is not emulated properly](https://github.com/flipperdevices/flipperzero-firmware/issues/2775)
+- [#2864: NFC: CP-Z-2 (mod. MF-I) can't do anti-collision with Flipper Zero emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/2864)
+- [#3343: 15693 listener can get get into a failed in some noisy conditions and remain there until restart](https://github.com/flipperdevices/flipperzero-firmware/issues/3343)
+- [#3416: Amiibo rewriting to nfc apps for amiibo not working  not reading as nfc 215 tag ](https://github.com/flipperdevices/flipperzero-firmware/issues/3416)
+- [#3436: Flipper Zero Crashes when I try to use it. (Reading NFC, Saving IR Remote Sequences)](https://github.com/flipperdevices/flipperzero-firmware/issues/3436)
+- [#3566: Mifare DESFire Emulate UID not working](https://github.com/flipperdevices/flipperzero-firmware/issues/3566)
+- [#3618: FDI iPassan Mifare Plus emulation not working](https://github.com/flipperdevices/flipperzero-firmware/issues/3618)
+- [#3755: CC1101: Impossible to send a long preamble](https://github.com/flipperdevices/flipperzero-firmware/issues/3755)
+- [#3756: Flipper crashes when continuously opening and closing the Passport screen](https://github.com/flipperdevices/flipperzero-firmware/issues/3756)
+- [#3835: Attempting to read DESFire Card causes `furi_check()` crash](https://github.com/flipperdevices/flipperzero-firmware/issues/3835)
+- [#3848: MIFARE Classic 1K EV1 is recognized as 1K, 16 sectors/32 keys](https://github.com/flipperdevices/flipperzero-firmware/issues/3848)
+- [#3867: Flipper misidentifies Visonic_Powecode alarm signal as Dickert_MAHS.](https://github.com/flipperdevices/flipperzero-firmware/issues/3867)
+- [#3870: RFID not detecting some card types that other devices detect (e.g. Keysy) ](https://github.com/flipperdevices/flipperzero-firmware/issues/3870)
+- [#3910: `mbedtls.cfg.h` is not accessible when using local SDKs via uFBT](https://github.com/flipperdevices/flipperzero-firmware/issues/3910)
+- [#3911: NFC Emulation Not Working Since 0.94.1](https://github.com/flipperdevices/flipperzero-firmware/issues/3911)
+- [#4072: Bad USB feature ignores keyboard layout setting (DE-CH)](https://github.com/flipperdevices/flipperzero-firmware/issues/4072)
+- [#4073: Crash with RCP app](https://github.com/flipperdevices/flipperzero-firmware/issues/4073)
+- [#4108: NFC bus fault](https://github.com/flipperdevices/flipperzero-firmware/issues/4108)
+- [#4209: [NFC] Incorrect mapping of Ultralight C in memory](https://github.com/flipperdevices/flipperzero-firmware/issues/4209)
+- [#4248: Inconsistent file path syntax in CLI](https://github.com/flipperdevices/flipperzero-firmware/issues/4248)
+
+### Build System & Scripts (6 issues)
+
+- [#2053: Allow loader open to start streaming logs](https://github.com/flipperdevices/flipperzero-firmware/issues/2053)
+- [#3825: C++ Breakpoints not hit](https://github.com/flipperdevices/flipperzero-firmware/issues/3825)
+- [#3883: Blackmagic: Warning upon attaching to Flipper FW](https://github.com/flipperdevices/flipperzero-firmware/issues/3883)
+- [#3884: Blackmagic: Reset/Reset Device don't work if execution is suspended on `furi_check()`](https://github.com/flipperdevices/flipperzero-firmware/issues/3884)
+- [#3910: `mbedtls.cfg.h` is not accessible when using local SDKs via uFBT](https://github.com/flipperdevices/flipperzero-firmware/issues/3910)
+- [#3913: Consider enabling C++23 and C23](https://github.com/flipperdevices/flipperzero-firmware/issues/3913)
+
+### Core+Services (25 issues)
+
+- [#1158: [Power] Option to reduce charging limit for increased battery longevity](https://github.com/flipperdevices/flipperzero-firmware/issues/1158)
+- [#1630: Flipper Auto Shutdown after inactivity](https://github.com/flipperdevices/flipperzero-firmware/issues/1630)
+- [#2596: Set minimum battery voltage](https://github.com/flipperdevices/flipperzero-firmware/issues/2596)
+- [#2925: Stealth mode](https://github.com/flipperdevices/flipperzero-firmware/issues/2925)
+- [#3224: Favorites API](https://github.com/flipperdevices/flipperzero-firmware/issues/3224)
+- [#3242: Show time in main menu instead of animations](https://github.com/flipperdevices/flipperzero-firmware/issues/3242)
+- [#3296: Inhibit automatic screen locking when connected via USB CDC](https://github.com/flipperdevices/flipperzero-firmware/issues/3296)
+- [#3426: Canvas: Fast blit function(s)](https://github.com/flipperdevices/flipperzero-firmware/issues/3426)
+- [#3534: API request: Free heap blocks available (same as memmgr_heap_printf_free_blocks)](https://github.com/flipperdevices/flipperzero-firmware/issues/3534)
+- [#3593: Suggestion Add xp/lvl up xp](https://github.com/flipperdevices/flipperzero-firmware/issues/3593)
+- [#3629: Custom crash/assert messages for FAPs](https://github.com/flipperdevices/flipperzero-firmware/issues/3629)
+- [#3662: Shareable id](https://github.com/flipperdevices/flipperzero-firmware/issues/3662)
+- [#3667: Feature NFC File Browser improved navigation](https://github.com/flipperdevices/flipperzero-firmware/issues/3667)
+- [#3756: Flipper crashes when continuously opening and closing the Passport screen](https://github.com/flipperdevices/flipperzero-firmware/issues/3756)
+- [#3825: C++ Breakpoints not hit](https://github.com/flipperdevices/flipperzero-firmware/issues/3825)
+- [#3876: Mouse Clicker Should have a "0" value setting for "as fast as possible"](https://github.com/flipperdevices/flipperzero-firmware/issues/3876)
+- [#3981: Show alarm icon in status bar if alarm set](https://github.com/flipperdevices/flipperzero-firmware/issues/3981)
+- [#3994: Clock & Alarm - lot of improvements needed](https://github.com/flipperdevices/flipperzero-firmware/issues/3994)
+- [#4037: Feature Request: Crontab](https://github.com/flipperdevices/flipperzero-firmware/issues/4037)
+- [#4073: Crash with RCP app](https://github.com/flipperdevices/flipperzero-firmware/issues/4073)
+- [#4079: Export BLE buffers in SKD](https://github.com/flipperdevices/flipperzero-firmware/issues/4079)
+- [#4130: Hook for Favorites menu](https://github.com/flipperdevices/flipperzero-firmware/issues/4130)
+- [#4152: I2C Slave mode](https://github.com/flipperdevices/flipperzero-firmware/issues/4152)
+- [#4248: Inconsistent file path syntax in CLI](https://github.com/flipperdevices/flipperzero-firmware/issues/4248)
+- [#4281: [mbedtls] Add ECDH](https://github.com/flipperdevices/flipperzero-firmware/issues/4281)
+
+### Documentation (1 issues)
+
+- [#4104: Question regarding (non)consistency of blocking/internal animation manifests](https://github.com/flipperdevices/flipperzero-firmware/issues/4104)
+
+### Feature Request (95 issues)
+
+- [#1038: Feature Request: i2c and SPI bridge to USB](https://github.com/flipperdevices/flipperzero-firmware/issues/1038)
+- [#1040: Feature Request: "Twin Duck" usb rubber ducky emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/1040)
+- [#1158: [Power] Option to reduce charging limit for increased battery longevity](https://github.com/flipperdevices/flipperzero-firmware/issues/1158)
+- [#1171: Program multi-key IR inputs](https://github.com/flipperdevices/flipperzero-firmware/issues/1171)
+- [#1234: Two-dimensional layout for saved remotes](https://github.com/flipperdevices/flipperzero-firmware/issues/1234)
+- [#1290: Rename LiftMaster_3XX to Security+1.0_3XX](https://github.com/flipperdevices/flipperzero-firmware/issues/1290)
+- [#1534: Hitag2 Support](https://github.com/flipperdevices/flipperzero-firmware/issues/1534)
+- [#1556: SubGHz Read and Read Raw to retain configs after exit](https://github.com/flipperdevices/flipperzero-firmware/issues/1556)
+- [#1565: U2F via NFC](https://github.com/flipperdevices/flipperzero-firmware/issues/1565)
+- [#1630: Flipper Auto Shutdown after inactivity](https://github.com/flipperdevices/flipperzero-firmware/issues/1630)
+- [#1656: Add badusb configs](https://github.com/flipperdevices/flipperzero-firmware/issues/1656)
+- [#1688: Legic Prime support](https://github.com/flipperdevices/flipperzero-firmware/issues/1688)
+- [#1715: ISO 14443 Type A communication sniffing](https://github.com/flipperdevices/flipperzero-firmware/issues/1715)
+- [#1800: Remote Macros](https://github.com/flipperdevices/flipperzero-firmware/issues/1800)
+- [#1886: NFC st25ta support](https://github.com/flipperdevices/flipperzero-firmware/issues/1886)
+- [#1934: Hopper frequency presets](https://github.com/flipperdevices/flipperzero-firmware/issues/1934)
+- [#2031: Don't attach the device name in all BLE advertising packages](https://github.com/flipperdevices/flipperzero-firmware/issues/2031)
+- [#2053: Allow loader open to start streaming logs](https://github.com/flipperdevices/flipperzero-firmware/issues/2053)
+- [#2079: ED25519 support for U2F](https://github.com/flipperdevices/flipperzero-firmware/issues/2079)
+- [#2104: Change USB Vendor ID and Product ID to something non generic](https://github.com/flipperdevices/flipperzero-firmware/issues/2104)
+- [#2231: Apple magsafe emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/2231)
+- [#2385: MiZiP keys and card read support](https://github.com/flipperdevices/flipperzero-firmware/issues/2385)
+- [#2386: Indala 224 card not being read](https://github.com/flipperdevices/flipperzero-firmware/issues/2386)
+- [#2465: Detect SL (sweden transport card) NFC](https://github.com/flipperdevices/flipperzero-firmware/issues/2465)
+- [#2513: U2F over Bluetooth](https://github.com/flipperdevices/flipperzero-firmware/issues/2513)
+- [#2578: New RFID Card Protocol Support (ProxLite/Entree Prox)](https://github.com/flipperdevices/flipperzero-firmware/issues/2578)
+- [#2634: Can't read my EGYM RFID card](https://github.com/flipperdevices/flipperzero-firmware/issues/2634)
+- [#2642: Shortcuts to change frequency in Sub-GHz Read ](https://github.com/flipperdevices/flipperzero-firmware/issues/2642)
+- [#2729: Making your own Infrared playlist ](https://github.com/flipperdevices/flipperzero-firmware/issues/2729)
+- [#2777: RFID Raw - Keri Systems PKT-10X Standard Light Proximity Key Tag](https://github.com/flipperdevices/flipperzero-firmware/issues/2777)
+- [#2796: Flipper unable to read access card](https://github.com/flipperdevices/flipperzero-firmware/issues/2796)
+- [#2805: [NFC] Flipper Emulation stopped working on BAS-IP BME-03 after enabling reader's security profile](https://github.com/flipperdevices/flipperzero-firmware/issues/2805)
+- [#2838: Frequencies allowed for Costa Rica](https://github.com/flipperdevices/flipperzero-firmware/issues/2838)
+- [#2859: NFC: Copy tag content to empty tags instead of initial card](https://github.com/flipperdevices/flipperzero-firmware/issues/2859)
+- [#2866: 134,2khz RFID Texas instruments](https://github.com/flipperdevices/flipperzero-firmware/issues/2866)
+- [#2877: U2F Security Key not supported in Windows 11](https://github.com/flipperdevices/flipperzero-firmware/issues/2877)
+- [#2898: Buttons for ONN brand ROKU TVs ](https://github.com/flipperdevices/flipperzero-firmware/issues/2898)
+- [#2925: Stealth mode](https://github.com/flipperdevices/flipperzero-firmware/issues/2925)
+- [#2943: RFID RAW reading card (Honeywell)](https://github.com/flipperdevices/flipperzero-firmware/issues/2943)
+- [#2995: RFID Farpointe Pyramid support](https://github.com/flipperdevices/flipperzero-firmware/issues/2995)
+- [#3051: RFID EM4X50 protocol support](https://github.com/flipperdevices/flipperzero-firmware/issues/3051)
+- [#3159: NFC: Show card sector access log after emulation ](https://github.com/flipperdevices/flipperzero-firmware/issues/3159)
+- [#3182: Add new SubGhz protocol for Clemsa MasterCode MV12](https://github.com/flipperdevices/flipperzero-firmware/issues/3182)
+- [#3197: KDF plugins](https://github.com/flipperdevices/flipperzero-firmware/issues/3197)
+- [#3224: Favorites API](https://github.com/flipperdevices/flipperzero-firmware/issues/3224)
+- [#3276: cli nfc command does not work after NFC refactor](https://github.com/flipperdevices/flipperzero-firmware/issues/3276)
+- [#3296: Inhibit automatic screen locking when connected via USB CDC](https://github.com/flipperdevices/flipperzero-firmware/issues/3296)
+- [#3353: Request for NLD BEP keyboard Layout inclusion (Nederland form belgie)](https://github.com/flipperdevices/flipperzero-firmware/issues/3353)
+- [#3426: Canvas: Fast blit function(s)](https://github.com/flipperdevices/flipperzero-firmware/issues/3426)
+- [#3454: NFC: (Bus card) Cant be emulated. Only scanned.](https://github.com/flipperdevices/flipperzero-firmware/issues/3454)
+- [#3455: Non-Important UI changes](https://github.com/flipperdevices/flipperzero-firmware/issues/3455)
+- [#3491: Allow duplicating/modifying NFC-V / ISO 15693 tags to get write new lifeionizers NFC tags](https://github.com/flipperdevices/flipperzero-firmware/issues/3491)
+- [#3494: Keri RFID NXT not reading](https://github.com/flipperdevices/flipperzero-firmware/issues/3494)
+- [#3534: API request: Free heap blocks available (same as memmgr_heap_printf_free_blocks)](https://github.com/flipperdevices/flipperzero-firmware/issues/3534)
+- [#3591: Password protection for T55xx](https://github.com/flipperdevices/flipperzero-firmware/issues/3591)
+- [#3593: Suggestion Add xp/lvl up xp](https://github.com/flipperdevices/flipperzero-firmware/issues/3593)
+- [#3599: Suggestion: Add NFC Tag Writing/wiping Option in the “More>” Menu (write to NFC Tag/wipe NFC Tag)](https://github.com/flipperdevices/flipperzero-firmware/issues/3599)
+- [#3609: NFC Plugin Interface Expansions](https://github.com/flipperdevices/flipperzero-firmware/issues/3609)
+- [#3667: Feature NFC File Browser improved navigation](https://github.com/flipperdevices/flipperzero-firmware/issues/3667)
+- [#3677: A JavaScript module for handling a button press](https://github.com/flipperdevices/flipperzero-firmware/issues/3677)
+- [#3678: a JavaScript API for loading and drawing from a spritesheet](https://github.com/flipperdevices/flipperzero-firmware/issues/3678)
+- [#3687: 125kHz fob not read / Protocol implementation?](https://github.com/flipperdevices/flipperzero-firmware/issues/3687)
+- [#3704: IL region, sub-ghz missing allowed frequencies](https://github.com/flipperdevices/flipperzero-firmware/issues/3704)
+- [#3752: LFRFID: Indala E9 Support](https://github.com/flipperdevices/flipperzero-firmware/issues/3752)
+- [#3778: Support multiple devices for BT remote](https://github.com/flipperdevices/flipperzero-firmware/issues/3778)
+- [#3818: T5577 Feature Request - dump / restore / compare feature](https://github.com/flipperdevices/flipperzero-firmware/issues/3818)
+- [#3821: RFID Read problem ](https://github.com/flipperdevices/flipperzero-firmware/issues/3821)
+- [#3833: JS - Token reading](https://github.com/flipperdevices/flipperzero-firmware/issues/3833)
+- [#3876: Mouse Clicker Should have a "0" value setting for "as fast as possible"](https://github.com/flipperdevices/flipperzero-firmware/issues/3876)
+- [#3877: Less granular value selection in Bluetooth HID Mouse Clicker](https://github.com/flipperdevices/flipperzero-firmware/issues/3877)
+- [#3898: Universal Remote Feature - Enhancement Request](https://github.com/flipperdevices/flipperzero-firmware/issues/3898)
+- [#3913: Consider enabling C++23 and C23](https://github.com/flipperdevices/flipperzero-firmware/issues/3913)
+- [#3938: [Sub-Ghz] Request support for Sherlotronics 403.55Mhz Transmitter](https://github.com/flipperdevices/flipperzero-firmware/issues/3938)
+- [#3939: readKeyState function for badusb mjs module](https://github.com/flipperdevices/flipperzero-firmware/issues/3939)
+- [#3984: RFID Read problem](https://github.com/flipperdevices/flipperzero-firmware/issues/3984)
+- [#3994: Clock & Alarm - lot of improvements needed](https://github.com/flipperdevices/flipperzero-firmware/issues/3994)
+- [#4002: RFE: Cannot write NFC-V tag](https://github.com/flipperdevices/flipperzero-firmware/issues/4002)
+- [#4007: universal IR](https://github.com/flipperdevices/flipperzero-firmware/issues/4007)
+- [#4011: change Bluetooth / device name](https://github.com/flipperdevices/flipperzero-firmware/issues/4011)
+- [#4012: Flipper Zero Mifare Plus 2K support (SL1 ONLY)](https://github.com/flipperdevices/flipperzero-firmware/issues/4012)
+- [#4016: BadUSB F13-F24 keys support not functional](https://github.com/flipperdevices/flipperzero-firmware/issues/4016)
+- [#4026: DESFire Light shows as unknown](https://github.com/flipperdevices/flipperzero-firmware/issues/4026)
+- [#4037: Feature Request: Crontab](https://github.com/flipperdevices/flipperzero-firmware/issues/4037)
+- [#4063: RFID card not recognized](https://github.com/flipperdevices/flipperzero-firmware/issues/4063)
+- [#4079: Export BLE buffers in SKD](https://github.com/flipperdevices/flipperzero-firmware/issues/4079)
+- [#4106: NFC Reading Issue with ISO 14443-3A Mifare Ultralight Card](https://github.com/flipperdevices/flipperzero-firmware/issues/4106)
+- [#4130: Hook for Favorites menu](https://github.com/flipperdevices/flipperzero-firmware/issues/4130)
+- [#4138: Add two BART Stations to Clipper Database](https://github.com/flipperdevices/flipperzero-firmware/issues/4138)
+- [#4152: I2C Slave mode](https://github.com/flipperdevices/flipperzero-firmware/issues/4152)
+- [#4200: Enhance SubGhz with protocol command cycling](https://github.com/flipperdevices/flipperzero-firmware/issues/4200)
+- [#4218: [Buetooth] Why is the extra beacon size limited to 31?](https://github.com/flipperdevices/flipperzero-firmware/issues/4218)
+- [#4250: Add ability to verify written tags/buttons](https://github.com/flipperdevices/flipperzero-firmware/issues/4250)
+- [#4253: Adding a JS command to directly exit the application](https://github.com/flipperdevices/flipperzero-firmware/issues/4253)
+- [#4263: Weather station: support for LaCrosse TX141-BV3](https://github.com/flipperdevices/flipperzero-firmware/issues/4263)
+- [#4281: [mbedtls] Add ECDH](https://github.com/flipperdevices/flipperzero-firmware/issues/4281)
+
+### Infrared (7 issues)
+
+- [#1171: Program multi-key IR inputs](https://github.com/flipperdevices/flipperzero-firmware/issues/1171)
+- [#1234: Two-dimensional layout for saved remotes](https://github.com/flipperdevices/flipperzero-firmware/issues/1234)
+- [#1800: Remote Macros](https://github.com/flipperdevices/flipperzero-firmware/issues/1800)
+- [#2729: Making your own Infrared playlist ](https://github.com/flipperdevices/flipperzero-firmware/issues/2729)
+- [#2898: Buttons for ONN brand ROKU TVs ](https://github.com/flipperdevices/flipperzero-firmware/issues/2898)
+- [#3898: Universal Remote Feature - Enhancement Request](https://github.com/flipperdevices/flipperzero-firmware/issues/3898)
+- [#4007: universal IR](https://github.com/flipperdevices/flipperzero-firmware/issues/4007)
+
+### JS (6 issues)
+
+- [#3677: A JavaScript module for handling a button press](https://github.com/flipperdevices/flipperzero-firmware/issues/3677)
+- [#3678: a JavaScript API for loading and drawing from a spritesheet](https://github.com/flipperdevices/flipperzero-firmware/issues/3678)
+- [#3833: JS - Token reading](https://github.com/flipperdevices/flipperzero-firmware/issues/3833)
+- [#3939: readKeyState function for badusb mjs module](https://github.com/flipperdevices/flipperzero-firmware/issues/3939)
+- [#4214: furi_hal_hid_get_led_state() returns 0 regardless of keyboard state](https://github.com/flipperdevices/flipperzero-firmware/issues/4214)
+- [#4253: Adding a JS command to directly exit the application](https://github.com/flipperdevices/flipperzero-firmware/issues/4253)
+
+### NFC (50 issues)
+
+- [#1468: NFC Emulation of previously saved Mifare classic 1k card does not work.](https://github.com/flipperdevices/flipperzero-firmware/issues/1468)
+- [#1565: U2F via NFC](https://github.com/flipperdevices/flipperzero-firmware/issues/1565)
+- [#1688: Legic Prime support](https://github.com/flipperdevices/flipperzero-firmware/issues/1688)
+- [#1715: ISO 14443 Type A communication sniffing](https://github.com/flipperdevices/flipperzero-firmware/issues/1715)
+- [#1886: NFC st25ta support](https://github.com/flipperdevices/flipperzero-firmware/issues/1886)
+- [#2231: Apple magsafe emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/2231)
+- [#2385: MiZiP keys and card read support](https://github.com/flipperdevices/flipperzero-firmware/issues/2385)
+- [#2465: Detect SL (sweden transport card) NFC](https://github.com/flipperdevices/flipperzero-firmware/issues/2465)
+- [#2562: Skylanders real-time write issue](https://github.com/flipperdevices/flipperzero-firmware/issues/2562)
+- [#2634: Can't read my EGYM RFID card](https://github.com/flipperdevices/flipperzero-firmware/issues/2634)
+- [#2775: Mifare Plus golmar key is not emulated properly](https://github.com/flipperdevices/flipperzero-firmware/issues/2775)
+- [#2796: Flipper unable to read access card](https://github.com/flipperdevices/flipperzero-firmware/issues/2796)
+- [#2805: [NFC] Flipper Emulation stopped working on BAS-IP BME-03 after enabling reader's security profile](https://github.com/flipperdevices/flipperzero-firmware/issues/2805)
+- [#2859: NFC: Copy tag content to empty tags instead of initial card](https://github.com/flipperdevices/flipperzero-firmware/issues/2859)
+- [#2864: NFC: CP-Z-2 (mod. MF-I) can't do anti-collision with Flipper Zero emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/2864)
+- [#3159: NFC: Show card sector access log after emulation ](https://github.com/flipperdevices/flipperzero-firmware/issues/3159)
+- [#3197: KDF plugins](https://github.com/flipperdevices/flipperzero-firmware/issues/3197)
+- [#3276: cli nfc command does not work after NFC refactor](https://github.com/flipperdevices/flipperzero-firmware/issues/3276)
+- [#3282: NTAG216 Unlocking Issue](https://github.com/flipperdevices/flipperzero-firmware/issues/3282)
+- [#3331: New NFC scanner APIs don't appear to work when used directly](https://github.com/flipperdevices/flipperzero-firmware/issues/3331)
+- [#3343: 15693 listener can get get into a failed in some noisy conditions and remain there until restart](https://github.com/flipperdevices/flipperzero-firmware/issues/3343)
+- [#3416: Amiibo rewriting to nfc apps for amiibo not working  not reading as nfc 215 tag ](https://github.com/flipperdevices/flipperzero-firmware/issues/3416)
+- [#3436: Flipper Zero Crashes when I try to use it. (Reading NFC, Saving IR Remote Sequences)](https://github.com/flipperdevices/flipperzero-firmware/issues/3436)
+- [#3454: NFC: (Bus card) Cant be emulated. Only scanned.](https://github.com/flipperdevices/flipperzero-firmware/issues/3454)
+- [#3491: Allow duplicating/modifying NFC-V / ISO 15693 tags to get write new lifeionizers NFC tags](https://github.com/flipperdevices/flipperzero-firmware/issues/3491)
+- [#3566: Mifare DESFire Emulate UID not working](https://github.com/flipperdevices/flipperzero-firmware/issues/3566)
+- [#3599: Suggestion: Add NFC Tag Writing/wiping Option in the “More>” Menu (write to NFC Tag/wipe NFC Tag)](https://github.com/flipperdevices/flipperzero-firmware/issues/3599)
+- [#3609: NFC Plugin Interface Expansions](https://github.com/flipperdevices/flipperzero-firmware/issues/3609)
+- [#3618: FDI iPassan Mifare Plus emulation not working](https://github.com/flipperdevices/flipperzero-firmware/issues/3618)
+- [#3633: Cant read NFC tag](https://github.com/flipperdevices/flipperzero-firmware/issues/3633)
+- [#3638: NFC: Equivalent of NfcWorkerEventSuccess from before NFC refactor](https://github.com/flipperdevices/flipperzero-firmware/issues/3638)
+- [#3641: NFC: furi_check_failed crash while reading MIKRON NFC on 0.101.2](https://github.com/flipperdevices/flipperzero-firmware/issues/3641)
+- [#3662: Shareable id](https://github.com/flipperdevices/flipperzero-firmware/issues/3662)
+- [#3772: MIFARE Ultralight C hex dump shows bogus data for locked pages](https://github.com/flipperdevices/flipperzero-firmware/issues/3772)
+- [#3835: Attempting to read DESFire Card causes `furi_check()` crash](https://github.com/flipperdevices/flipperzero-firmware/issues/3835)
+- [#3848: MIFARE Classic 1K EV1 is recognized as 1K, 16 sectors/32 keys](https://github.com/flipperdevices/flipperzero-firmware/issues/3848)
+- [#3853: Reading an emulated Amiibo causes Flipper Zero to crash using NFC read but works using NFC Read specific card type](https://github.com/flipperdevices/flipperzero-firmware/issues/3853)
+- [#3907: NFC Read does not identify MF Ultralight card - OFW 1.01](https://github.com/flipperdevices/flipperzero-firmware/issues/3907)
+- [#3911: NFC Emulation Not Working Since 0.94.1](https://github.com/flipperdevices/flipperzero-firmware/issues/3911)
+- [#4002: RFE: Cannot write NFC-V tag](https://github.com/flipperdevices/flipperzero-firmware/issues/4002)
+- [#4012: Flipper Zero Mifare Plus 2K support (SL1 ONLY)](https://github.com/flipperdevices/flipperzero-firmware/issues/4012)
+- [#4026: DESFire Light shows as unknown](https://github.com/flipperdevices/flipperzero-firmware/issues/4026)
+- [#4089: Bug in Manual Read: effects slix nfc, possibly others](https://github.com/flipperdevices/flipperzero-firmware/issues/4089)
+- [#4106: NFC Reading Issue with ISO 14443-3A Mifare Ultralight Card](https://github.com/flipperdevices/flipperzero-firmware/issues/4106)
+- [#4108: NFC bus fault](https://github.com/flipperdevices/flipperzero-firmware/issues/4108)
+- [#4138: Add two BART Stations to Clipper Database](https://github.com/flipperdevices/flipperzero-firmware/issues/4138)
+- [#4194: Technical Specification for Flipper Zero Mifare Classic 1K Enhancement](https://github.com/flipperdevices/flipperzero-firmware/issues/4194)
+- [#4196: Technical Specification: NFC Tag Information Application for Flipper Zero](https://github.com/flipperdevices/flipperzero-firmware/issues/4196)
+- [#4209: [NFC] Incorrect mapping of Ultralight C in memory](https://github.com/flipperdevices/flipperzero-firmware/issues/4209)
+- [#4249: Reading NFC card while connected via USB to a computer and to qFlipper leads to a OOM Crash](https://github.com/flipperdevices/flipperzero-firmware/issues/4249)
+
+### New Feature (1 issues)
+
+- [#3981: Show alarm icon in status bar if alarm set](https://github.com/flipperdevices/flipperzero-firmware/issues/3981)
+
+### RFID 125kHz (23 issues)
+
+- [#1534: Hitag2 Support](https://github.com/flipperdevices/flipperzero-firmware/issues/1534)
+- [#2385: MiZiP keys and card read support](https://github.com/flipperdevices/flipperzero-firmware/issues/2385)
+- [#2386: Indala 224 card not being read](https://github.com/flipperdevices/flipperzero-firmware/issues/2386)
+- [#2578: New RFID Card Protocol Support (ProxLite/Entree Prox)](https://github.com/flipperdevices/flipperzero-firmware/issues/2578)
+- [#2733: NexWatch/NexKey support added in .84 not working - will not read cards](https://github.com/flipperdevices/flipperzero-firmware/issues/2733)
+- [#2777: RFID Raw - Keri Systems PKT-10X Standard Light Proximity Key Tag](https://github.com/flipperdevices/flipperzero-firmware/issues/2777)
+- [#2796: Flipper unable to read access card](https://github.com/flipperdevices/flipperzero-firmware/issues/2796)
+- [#2866: 134,2khz RFID Texas instruments](https://github.com/flipperdevices/flipperzero-firmware/issues/2866)
+- [#2943: RFID RAW reading card (Honeywell)](https://github.com/flipperdevices/flipperzero-firmware/issues/2943)
+- [#2995: RFID Farpointe Pyramid support](https://github.com/flipperdevices/flipperzero-firmware/issues/2995)
+- [#3051: RFID EM4X50 protocol support](https://github.com/flipperdevices/flipperzero-firmware/issues/3051)
+- [#3494: Keri RFID NXT not reading](https://github.com/flipperdevices/flipperzero-firmware/issues/3494)
+- [#3591: Password protection for T55xx](https://github.com/flipperdevices/flipperzero-firmware/issues/3591)
+- [#3687: 125kHz fob not read / Protocol implementation?](https://github.com/flipperdevices/flipperzero-firmware/issues/3687)
+- [#3752: LFRFID: Indala E9 Support](https://github.com/flipperdevices/flipperzero-firmware/issues/3752)
+- [#3818: T5577 Feature Request - dump / restore / compare feature](https://github.com/flipperdevices/flipperzero-firmware/issues/3818)
+- [#3821: RFID Read problem ](https://github.com/flipperdevices/flipperzero-firmware/issues/3821)
+- [#3870: RFID not detecting some card types that other devices detect (e.g. Keysy) ](https://github.com/flipperdevices/flipperzero-firmware/issues/3870)
+- [#3984: RFID Read problem](https://github.com/flipperdevices/flipperzero-firmware/issues/3984)
+- [#4063: RFID card not recognized](https://github.com/flipperdevices/flipperzero-firmware/issues/4063)
+- [#4269: Support non-standard Indala RFID fob](https://github.com/flipperdevices/flipperzero-firmware/issues/4269)
+- [#4275: RFID Pet-animal](https://github.com/flipperdevices/flipperzero-firmware/issues/4275)
+- [#4276: RFID keyfob](https://github.com/flipperdevices/flipperzero-firmware/issues/4276)
+
+### Sub-GHz (15 issues)
+
+- [#1290: Rename LiftMaster_3XX to Security+1.0_3XX](https://github.com/flipperdevices/flipperzero-firmware/issues/1290)
+- [#1556: SubGHz Read and Read Raw to retain configs after exit](https://github.com/flipperdevices/flipperzero-firmware/issues/1556)
+- [#1934: Hopper frequency presets](https://github.com/flipperdevices/flipperzero-firmware/issues/1934)
+- [#2609: Fix saving selected settings in Sub-GHz](https://github.com/flipperdevices/flipperzero-firmware/issues/2609)
+- [#2642: Shortcuts to change frequency in Sub-GHz Read ](https://github.com/flipperdevices/flipperzero-firmware/issues/2642)
+- [#2838: Frequencies allowed for Costa Rica](https://github.com/flipperdevices/flipperzero-firmware/issues/2838)
+- [#3182: Add new SubGhz protocol for Clemsa MasterCode MV12](https://github.com/flipperdevices/flipperzero-firmware/issues/3182)
+- [#3662: Shareable id](https://github.com/flipperdevices/flipperzero-firmware/issues/3662)
+- [#3704: IL region, sub-ghz missing allowed frequencies](https://github.com/flipperdevices/flipperzero-firmware/issues/3704)
+- [#3755: CC1101: Impossible to send a long preamble](https://github.com/flipperdevices/flipperzero-firmware/issues/3755)
+- [#3867: Flipper misidentifies Visonic_Powecode alarm signal as Dickert_MAHS.](https://github.com/flipperdevices/flipperzero-firmware/issues/3867)
+- [#3938: [Sub-Ghz] Request support for Sherlotronics 403.55Mhz Transmitter](https://github.com/flipperdevices/flipperzero-firmware/issues/3938)
+- [#4086: Region Mhz locks are incorrect for country code IM](https://github.com/flipperdevices/flipperzero-firmware/issues/4086)
+- [#4200: Enhance SubGhz with protocol command cycling](https://github.com/flipperdevices/flipperzero-firmware/issues/4200)
+- [#4263: Weather station: support for LaCrosse TX141-BV3](https://github.com/flipperdevices/flipperzero-firmware/issues/4263)
+
+### Triage (22 issues)
+
+- [#3618: FDI iPassan Mifare Plus emulation not working](https://github.com/flipperdevices/flipperzero-firmware/issues/3618)
+- [#3633: Cant read NFC tag](https://github.com/flipperdevices/flipperzero-firmware/issues/3633)
+- [#3638: NFC: Equivalent of NfcWorkerEventSuccess from before NFC refactor](https://github.com/flipperdevices/flipperzero-firmware/issues/3638)
+- [#3641: NFC: furi_check_failed crash while reading MIKRON NFC on 0.101.2](https://github.com/flipperdevices/flipperzero-firmware/issues/3641)
+- [#3772: MIFARE Ultralight C hex dump shows bogus data for locked pages](https://github.com/flipperdevices/flipperzero-firmware/issues/3772)
+- [#3853: Reading an emulated Amiibo causes Flipper Zero to crash using NFC read but works using NFC Read specific card type](https://github.com/flipperdevices/flipperzero-firmware/issues/3853)
+- [#3883: Blackmagic: Warning upon attaching to Flipper FW](https://github.com/flipperdevices/flipperzero-firmware/issues/3883)
+- [#3884: Blackmagic: Reset/Reset Device don't work if execution is suspended on `furi_check()`](https://github.com/flipperdevices/flipperzero-firmware/issues/3884)
+- [#3907: NFC Read does not identify MF Ultralight card - OFW 1.01](https://github.com/flipperdevices/flipperzero-firmware/issues/3907)
+- [#4089: Bug in Manual Read: effects slix nfc, possibly others](https://github.com/flipperdevices/flipperzero-firmware/issues/4089)
+- [#4148: BadUSB script runs too fast for notepad.exe on Windows 11](https://github.com/flipperdevices/flipperzero-firmware/issues/4148)
+- [#4162: Connecting as USB HID keyboard cannot read state of keyboard LEDs (CapsLock/NumLock/ScrollLock)](https://github.com/flipperdevices/flipperzero-firmware/issues/4162)
+- [#4194: Technical Specification for Flipper Zero Mifare Classic 1K Enhancement](https://github.com/flipperdevices/flipperzero-firmware/issues/4194)
+- [#4196: Technical Specification: NFC Tag Information Application for Flipper Zero](https://github.com/flipperdevices/flipperzero-firmware/issues/4196)
+- [#4214: furi_hal_hid_get_led_state() returns 0 regardless of keyboard state](https://github.com/flipperdevices/flipperzero-firmware/issues/4214)
+- [#4247: NFC files not syncing via Bluetooth from Flipper to Android app (v1.8)](https://github.com/flipperdevices/flipperzero-firmware/issues/4247)
+- [#4249: Reading NFC card while connected via USB to a computer and to qFlipper leads to a OOM Crash](https://github.com/flipperdevices/flipperzero-firmware/issues/4249)
+- [#4258: Internal GDB error when trying to flash firmware using wifi devboard](https://github.com/flipperdevices/flipperzero-firmware/issues/4258)
+- [#4262: Error while building firmware](https://github.com/flipperdevices/flipperzero-firmware/issues/4262)
+- [#4269: Support non-standard Indala RFID fob](https://github.com/flipperdevices/flipperzero-firmware/issues/4269)
+- [#4275: RFID Pet-animal](https://github.com/flipperdevices/flipperzero-firmware/issues/4275)
+- [#4276: RFID keyfob](https://github.com/flipperdevices/flipperzero-firmware/issues/4276)
+
+### UI (6 issues)
+
+- [#1171: Program multi-key IR inputs](https://github.com/flipperdevices/flipperzero-firmware/issues/1171)
+- [#1234: Two-dimensional layout for saved remotes](https://github.com/flipperdevices/flipperzero-firmware/issues/1234)
+- [#2642: Shortcuts to change frequency in Sub-GHz Read ](https://github.com/flipperdevices/flipperzero-firmware/issues/2642)
+- [#3455: Non-Important UI changes](https://github.com/flipperdevices/flipperzero-firmware/issues/3455)
+- [#3593: Suggestion Add xp/lvl up xp](https://github.com/flipperdevices/flipperzero-firmware/issues/3593)
+- [#3772: MIFARE Ultralight C hex dump shows bogus data for locked pages](https://github.com/flipperdevices/flipperzero-firmware/issues/3772)
+
+### USB (13 issues)
+
+- [#1040: Feature Request: "Twin Duck" usb rubber ducky emulation](https://github.com/flipperdevices/flipperzero-firmware/issues/1040)
+- [#1158: [Power] Option to reduce charging limit for increased battery longevity](https://github.com/flipperdevices/flipperzero-firmware/issues/1158)
+- [#1656: Add badusb configs](https://github.com/flipperdevices/flipperzero-firmware/issues/1656)
+- [#2079: ED25519 support for U2F](https://github.com/flipperdevices/flipperzero-firmware/issues/2079)
+- [#2104: Change USB Vendor ID and Product ID to something non generic](https://github.com/flipperdevices/flipperzero-firmware/issues/2104)
+- [#2563: U2F does not work with some services](https://github.com/flipperdevices/flipperzero-firmware/issues/2563)
+- [#2877: U2F Security Key not supported in Windows 11](https://github.com/flipperdevices/flipperzero-firmware/issues/2877)
+- [#3353: Request for NLD BEP keyboard Layout inclusion (Nederland form belgie)](https://github.com/flipperdevices/flipperzero-firmware/issues/3353)
+- [#3876: Mouse Clicker Should have a "0" value setting for "as fast as possible"](https://github.com/flipperdevices/flipperzero-firmware/issues/3876)
+- [#3877: Less granular value selection in Bluetooth HID Mouse Clicker](https://github.com/flipperdevices/flipperzero-firmware/issues/3877)
+- [#4016: BadUSB F13-F24 keys support not functional](https://github.com/flipperdevices/flipperzero-firmware/issues/4016)
+- [#4072: Bad USB feature ignores keyboard layout setting (DE-CH)](https://github.com/flipperdevices/flipperzero-firmware/issues/4072)
+- [#4162: Connecting as USB HID keyboard cannot read state of keyboard LEDs (CapsLock/NumLock/ScrollLock)](https://github.com/flipperdevices/flipperzero-firmware/issues/4162)
+
+### Unlabeled (10 issues)
+
+- [#4272: При попытке подключить модуль "flipper" в js-скрипте ошибка](https://github.com/flipperdevices/flipperzero-firmware/issues/4272)
+- [#4289: Same bag as cards #2218](https://github.com/flipperdevices/flipperzero-firmware/issues/4289)
+- [#4300: NFC app refuses to write NDEF after tag was password-protected, misinterprets AUTH0 / lock bytes for NTAG21x (tested on genuine NTAG216)](https://github.com/flipperdevices/flipperzero-firmware/issues/4300)
+- [#4303: Freezing desktop animation](https://github.com/flipperdevices/flipperzero-firmware/issues/4303)
+- [#4307: How to use sub-GHz](https://github.com/flipperdevices/flipperzero-firmware/issues/4307)
+- [#4310: Incorrect Sub-GHz region lock for BH (Bahrain) — 433 MHz should be permitted](https://github.com/flipperdevices/flipperzero-firmware/issues/4310)
+- [#4314: Reading saved Felica Standart emulation by another FZ leads to its crash](https://github.com/flipperdevices/flipperzero-firmware/issues/4314)
+- [#4317: "System Protobuf Version timeout"](https://github.com/flipperdevices/flipperzero-firmware/issues/4317)
+- [#4321: NTAG215 emulation enables password auth and config lock too early](https://github.com/flipperdevices/flipperzero-firmware/issues/4321)
+- [#4322: Javascript - Infrared Module](https://github.com/flipperdevices/flipperzero-firmware/issues/4322)
+
+### iButton (1 issues)
+
+- [#1847: iButton ds1990a emulation doesn't work](https://github.com/flipperdevices/flipperzero-firmware/issues/1847)
+
+## All Issues (Chronological)
+
+- [#1038](https://github.com/flipperdevices/flipperzero-firmware/issues/1038): **Feature Request: i2c and SPI bridge to USB** (by @Patronics, 2022-03-17)
+  - Labels: Feature Request, Applications
+- [#1040](https://github.com/flipperdevices/flipperzero-firmware/issues/1040): **Feature Request: "Twin Duck" usb rubber ducky emulation** (by @Patronics, 2022-03-17)
+  - Labels: Feature Request, USB
+- [#1158](https://github.com/flipperdevices/flipperzero-firmware/issues/1158): **[Power] Option to reduce charging limit for increased battery longevity** (by @digitalcircuit, 2022-04-24)
+  - Labels: Feature Request, USB, Core+Services
+- [#1171](https://github.com/flipperdevices/flipperzero-firmware/issues/1171): **Program multi-key IR inputs** (by @edbrannin, 2022-04-26)
+  - Labels: Feature Request, Infrared, UI
+- [#1234](https://github.com/flipperdevices/flipperzero-firmware/issues/1234): **Two-dimensional layout for saved remotes** (by @lykahb, 2022-05-15)
+  - Labels: Feature Request, Infrared, UI
+- [#1290](https://github.com/flipperdevices/flipperzero-firmware/issues/1290): **Rename LiftMaster_3XX to Security+1.0_3XX** (by @xslim, 2022-06-02)
+  - Labels: Feature Request, Sub-GHz
+- [#1468](https://github.com/flipperdevices/flipperzero-firmware/issues/1468): **NFC Emulation of previously saved Mifare classic 1k card does not work.** (by @bolmar3, 2022-07-27)
+  - Labels: NFC, Bug
+- [#1534](https://github.com/flipperdevices/flipperzero-firmware/issues/1534): **Hitag2 Support** (by @eben80, 2022-08-04)
+  - Labels: Feature Request, RFID 125kHz
+- [#1556](https://github.com/flipperdevices/flipperzero-firmware/issues/1556): **SubGHz Read and Read Raw to retain configs after exit** (by @ppseprus, 2022-08-08)
+  - Labels: Feature Request, Sub-GHz
+- [#1565](https://github.com/flipperdevices/flipperzero-firmware/issues/1565): **U2F via NFC** (by @nicoSWD, 2022-08-09)
+  - Labels: Feature Request, NFC
+- [#1630](https://github.com/flipperdevices/flipperzero-firmware/issues/1630): **Flipper Auto Shutdown after inactivity** (by @ase1590, 2022-08-20)
+  - Labels: Feature Request, Core+Services
+- [#1656](https://github.com/flipperdevices/flipperzero-firmware/issues/1656): **Add badusb configs** (by @FalsePhilosopher, 2022-08-24)
+  - Labels: Feature Request, Backlog, USB
+- [#1688](https://github.com/flipperdevices/flipperzero-firmware/issues/1688): **Legic Prime support** (by @Builderhummel, 2022-08-31)
+  - Labels: Feature Request, NFC
+- [#1715](https://github.com/flipperdevices/flipperzero-firmware/issues/1715): **ISO 14443 Type A communication sniffing** (by @koalazak, 2022-09-07)
+  - Labels: Feature Request, NFC
+- [#1800](https://github.com/flipperdevices/flipperzero-firmware/issues/1800): **Remote Macros** (by @uintdev, 2022-09-28)
+  - Labels: Feature Request, Backlog, Infrared
+- [#1847](https://github.com/flipperdevices/flipperzero-firmware/issues/1847): **iButton ds1990a emulation doesn't work** (by @jagotu, 2022-10-07)
+  - Labels: Bug, iButton
+- [#1886](https://github.com/flipperdevices/flipperzero-firmware/issues/1886): **NFC st25ta support** (by @SkalkaA, 2022-10-17)
+  - Labels: Feature Request, Backlog, NFC
+- [#1934](https://github.com/flipperdevices/flipperzero-firmware/issues/1934): **Hopper frequency presets** (by @LowSkillDeveloper, 2022-10-26)
+  - Labels: Feature Request, Sub-GHz
+- [#2031](https://github.com/flipperdevices/flipperzero-firmware/issues/2031): **Don't attach the device name in all BLE advertising packages** (by @Semper-Viventem, 2022-11-20)
+  - Labels: Feature Request, Bluetooth
+- [#2053](https://github.com/flipperdevices/flipperzero-firmware/issues/2053): **Allow loader open to start streaming logs** (by @NZSmartie, 2022-11-26)
+  - Labels: Feature Request, Build System & Scripts
+- [#2079](https://github.com/flipperdevices/flipperzero-firmware/issues/2079): **ED25519 support for U2F** (by @exussum12, 2022-12-02)
+  - Labels: Feature Request, USB
+- [#2104](https://github.com/flipperdevices/flipperzero-firmware/issues/2104): **Change USB Vendor ID and Product ID to something non generic** (by @ikilledmypc, 2022-12-08)
+  - Labels: Feature Request, Backlog, USB
+- [#2231](https://github.com/flipperdevices/flipperzero-firmware/issues/2231): **Apple magsafe emulation** (by @bettse, 2022-12-31)
+  - Labels: Feature Request, NFC
+- [#2385](https://github.com/flipperdevices/flipperzero-firmware/issues/2385): **MiZiP keys and card read support** (by @LowSkillDeveloper, 2023-02-11)
+  - Labels: Feature Request, NFC, RFID 125kHz
+- [#2386](https://github.com/flipperdevices/flipperzero-firmware/issues/2386): **Indala 224 card not being read** (by @Divide-By-0, 2023-02-12)
+  - Labels: Feature Request, RFID 125kHz
+- [#2465](https://github.com/flipperdevices/flipperzero-firmware/issues/2465): **Detect SL (sweden transport card) NFC** (by @xSean145, 2023-03-05)
+  - Labels: Feature Request, NFC
+- [#2513](https://github.com/flipperdevices/flipperzero-firmware/issues/2513): **U2F over Bluetooth** (by @Kami-no, 2023-03-19)
+  - Labels: Feature Request, Backlog, Bluetooth
+- [#2562](https://github.com/flipperdevices/flipperzero-firmware/issues/2562): **Skylanders real-time write issue** (by @Mikeonut, 2023-04-04)
+  - Labels: NFC, Bug
+- [#2563](https://github.com/flipperdevices/flipperzero-firmware/issues/2563): **U2F does not work with some services** (by @JulyIghor, 2023-04-05)
+  - Labels: USB, Bug
+- [#2578](https://github.com/flipperdevices/flipperzero-firmware/issues/2578): **New RFID Card Protocol Support (ProxLite/Entree Prox)** (by @zigad, 2023-04-12)
+  - Labels: Feature Request, RFID 125kHz
+- [#2596](https://github.com/flipperdevices/flipperzero-firmware/issues/2596): **Set minimum battery voltage** (by @LeasyBen, 2023-04-19)
+  - Labels: Bug, Core+Services
+- [#2609](https://github.com/flipperdevices/flipperzero-firmware/issues/2609): **Fix saving selected settings in Sub-GHz** (by @krolchonok, 2023-04-24)
+  - Labels: Sub-GHz, Bug
+- [#2634](https://github.com/flipperdevices/flipperzero-firmware/issues/2634): **Can't read my EGYM RFID card** (by @Boringsapiens, 2023-05-04)
+  - Labels: Feature Request, NFC
+- [#2642](https://github.com/flipperdevices/flipperzero-firmware/issues/2642): **Shortcuts to change frequency in Sub-GHz Read ** (by @xologram, 2023-05-06)
+  - Labels: Feature Request, Sub-GHz, UI
+- [#2729](https://github.com/flipperdevices/flipperzero-firmware/issues/2729): **Making your own Infrared playlist ** (by @Re3koning, 2023-06-03)
+  - Labels: Feature Request, Infrared
+- [#2733](https://github.com/flipperdevices/flipperzero-firmware/issues/2733): **NexWatch/NexKey support added in .84 not working - will not read cards** (by @i-am-mandalore, 2023-06-05)
+  - Labels: RFID 125kHz, Bug
+- [#2775](https://github.com/flipperdevices/flipperzero-firmware/issues/2775): **Mifare Plus golmar key is not emulated properly** (by @mgrybyk, 2023-06-13)
+  - Labels: NFC, Bug
+- [#2777](https://github.com/flipperdevices/flipperzero-firmware/issues/2777): **RFID Raw - Keri Systems PKT-10X Standard Light Proximity Key Tag** (by @JReming85, 2023-06-16)
+  - Labels: Feature Request, RFID 125kHz
+- [#2796](https://github.com/flipperdevices/flipperzero-firmware/issues/2796): **Flipper unable to read access card** (by @DamianCPH, 2023-06-22)
+  - Labels: Feature Request, NFC, RFID 125kHz
+- [#2805](https://github.com/flipperdevices/flipperzero-firmware/issues/2805): **[NFC] Flipper Emulation stopped working on BAS-IP BME-03 after enabling reader's security profile** (by @mishamyte, 2023-06-26)
+  - Labels: Feature Request, NFC
+- [#2838](https://github.com/flipperdevices/flipperzero-firmware/issues/2838): **Frequencies allowed for Costa Rica** (by @ngonzalez456, 2023-07-04)
+  - Labels: Feature Request, Sub-GHz
+- [#2859](https://github.com/flipperdevices/flipperzero-firmware/issues/2859): **NFC: Copy tag content to empty tags instead of initial card** (by @akaash00, 2023-07-10)
+  - Labels: Feature Request, NFC
+- [#2864](https://github.com/flipperdevices/flipperzero-firmware/issues/2864): **NFC: CP-Z-2 (mod. MF-I) can't do anti-collision with Flipper Zero emulation** (by @AloneLiberty, 2023-07-11)
+  - Labels: NFC, Bug
+- [#2866](https://github.com/flipperdevices/flipperzero-firmware/issues/2866): **134,2khz RFID Texas instruments** (by @Marianovich, 2023-07-12)
+  - Labels: Feature Request, RFID 125kHz
+- [#2877](https://github.com/flipperdevices/flipperzero-firmware/issues/2877): **U2F Security Key not supported in Windows 11** (by @SystemOfTheCSGO, 2023-07-14)
+  - Labels: Feature Request, USB
+- [#2898](https://github.com/flipperdevices/flipperzero-firmware/issues/2898): **Buttons for ONN brand ROKU TVs ** (by @fennectech, 2023-07-19)
+  - Labels: Feature Request, Infrared
+- [#2925](https://github.com/flipperdevices/flipperzero-firmware/issues/2925): **Stealth mode** (by @Zarcolio, 2023-07-28)
+  - Labels: Feature Request, Core+Services
+- [#2943](https://github.com/flipperdevices/flipperzero-firmware/issues/2943): **RFID RAW reading card (Honeywell)** (by @M-Purple, 2023-08-03)
+  - Labels: Feature Request, RFID 125kHz
+- [#2995](https://github.com/flipperdevices/flipperzero-firmware/issues/2995): **RFID Farpointe Pyramid support** (by @Tylerrattv, 2023-08-21)
+  - Labels: Feature Request, RFID 125kHz
+- [#3051](https://github.com/flipperdevices/flipperzero-firmware/issues/3051): **RFID EM4X50 protocol support** (by @tcfsoft, 2023-09-07)
+  - Labels: Feature Request, RFID 125kHz
+- [#3159](https://github.com/flipperdevices/flipperzero-firmware/issues/3159): **NFC: Show card sector access log after emulation ** (by @mh-, 2023-10-19)
+  - Labels: Feature Request, NFC
+- [#3182](https://github.com/flipperdevices/flipperzero-firmware/issues/3182): **Add new SubGhz protocol for Clemsa MasterCode MV12** (by @flipperzelebro, 2023-11-01)
+  - Labels: Feature Request, Sub-GHz
+- [#3197](https://github.com/flipperdevices/flipperzero-firmware/issues/3197): **KDF plugins** (by @noproto, 2023-11-04)
+  - Labels: Feature Request, NFC
+- [#3224](https://github.com/flipperdevices/flipperzero-firmware/issues/3224): **Favorites API** (by @jstefa, 2023-11-17)
+  - Labels: Feature Request, Core+Services
+- [#3242](https://github.com/flipperdevices/flipperzero-firmware/issues/3242): **Show time in main menu instead of animations** (by @Danucosukosuko, 2023-11-24)
+  - Labels: Core+Services
+- [#3276](https://github.com/flipperdevices/flipperzero-firmware/issues/3276): **cli nfc command does not work after NFC refactor** (by @u0d7i, 2023-12-07)
+  - Labels: Feature Request, NFC
+- [#3282](https://github.com/flipperdevices/flipperzero-firmware/issues/3282): **NTAG216 Unlocking Issue** (by @droidXrobot, 2023-12-10)
+  - Labels: NFC
+- [#3296](https://github.com/flipperdevices/flipperzero-firmware/issues/3296): **Inhibit automatic screen locking when connected via USB CDC** (by @dogtopus, 2023-12-15)
+  - Labels: Feature Request, Core+Services
+- [#3331](https://github.com/flipperdevices/flipperzero-firmware/issues/3331): **New NFC scanner APIs don't appear to work when used directly** (by @str4d, 2023-12-31)
+  - Labels: NFC
+- [#3343](https://github.com/flipperdevices/flipperzero-firmware/issues/3343): **15693 listener can get get into a failed in some noisy conditions and remain there until restart** (by @nvx, 2024-01-05)
+  - Labels: NFC, Bug
+- [#3353](https://github.com/flipperdevices/flipperzero-firmware/issues/3353): **Request for NLD BEP keyboard Layout inclusion (Nederland form belgie)** (by @Soka109, 2024-01-09)
+  - Labels: Feature Request, USB
+- [#3416](https://github.com/flipperdevices/flipperzero-firmware/issues/3416): **Amiibo rewriting to nfc apps for amiibo not working  not reading as nfc 215 tag ** (by @olg857, 2024-01-31)
+  - Labels: NFC, Bug
+- [#3426](https://github.com/flipperdevices/flipperzero-firmware/issues/3426): **Canvas: Fast blit function(s)** (by @CookiePLMonster, 2024-02-05)
+  - Labels: Feature Request, Core+Services
+- [#3436](https://github.com/flipperdevices/flipperzero-firmware/issues/3436): **Flipper Zero Crashes when I try to use it. (Reading NFC, Saving IR Remote Sequences)** (by @I-Am-Skoot, 2024-02-09)
+  - Labels: NFC, Bug
+- [#3454](https://github.com/flipperdevices/flipperzero-firmware/issues/3454): **NFC: (Bus card) Cant be emulated. Only scanned.** (by @Killer74-hub, 2024-02-16)
+  - Labels: Feature Request, NFC
+- [#3455](https://github.com/flipperdevices/flipperzero-firmware/issues/3455): **Non-Important UI changes** (by @Tomi2965, 2024-02-16)
+  - Labels: Feature Request, UI
+- [#3491](https://github.com/flipperdevices/flipperzero-firmware/issues/3491): **Allow duplicating/modifying NFC-V / ISO 15693 tags to get write new lifeionizers NFC tags** (by @marcmerlin, 2024-03-01)
+  - Labels: Feature Request, NFC
+- [#3494](https://github.com/flipperdevices/flipperzero-firmware/issues/3494): **Keri RFID NXT not reading** (by @devopgirlie, 2024-03-04)
+  - Labels: Feature Request, RFID 125kHz
+- [#3534](https://github.com/flipperdevices/flipperzero-firmware/issues/3534): **API request: Free heap blocks available (same as memmgr_heap_printf_free_blocks)** (by @noproto, 2024-03-21)
+  - Labels: Feature Request, Core+Services
+- [#3566](https://github.com/flipperdevices/flipperzero-firmware/issues/3566): **Mifare DESFire Emulate UID not working** (by @Fabunator, 2024-04-03)
+  - Labels: NFC, Bug
+- [#3591](https://github.com/flipperdevices/flipperzero-firmware/issues/3591): **Password protection for T55xx** (by @mxcdoam, 2024-04-15)
+  - Labels: Feature Request, RFID 125kHz
+- [#3593](https://github.com/flipperdevices/flipperzero-firmware/issues/3593): **Suggestion Add xp/lvl up xp** (by @santi00001, 2024-04-16)
+  - Labels: Feature Request, UI, Core+Services
+- [#3599](https://github.com/flipperdevices/flipperzero-firmware/issues/3599): **Suggestion: Add NFC Tag Writing/wiping Option in the “More>” Menu (write to NFC Tag/wipe NFC Tag)** (by @Killer74-hub, 2024-04-17)
+  - Labels: Feature Request, NFC
+- [#3609](https://github.com/flipperdevices/flipperzero-firmware/issues/3609): **NFC Plugin Interface Expansions** (by @zacharyweiss, 2024-04-22)
+  - Labels: Feature Request, NFC
+- [#3618](https://github.com/flipperdevices/flipperzero-firmware/issues/3618): **FDI iPassan Mifare Plus emulation not working** (by @Tomi2965, 2024-04-26)
+  - Labels: NFC, Bug, Triage
+- [#3629](https://github.com/flipperdevices/flipperzero-firmware/issues/3629): **Custom crash/assert messages for FAPs** (by @CookiePLMonster, 2024-05-01)
+  - Labels: Core+Services
+- [#3633](https://github.com/flipperdevices/flipperzero-firmware/issues/3633): **Cant read NFC tag** (by @iv-the-red, 2024-05-03)
+  - Labels: NFC, Triage
+- [#3638](https://github.com/flipperdevices/flipperzero-firmware/issues/3638): **NFC: Equivalent of NfcWorkerEventSuccess from before NFC refactor** (by @GMMan, 2024-05-06)
+  - Labels: NFC, Triage
+- [#3641](https://github.com/flipperdevices/flipperzero-firmware/issues/3641): **NFC: furi_check_failed crash while reading MIKRON NFC on 0.101.2** (by @mxcdoam, 2024-05-08)
+  - Labels: NFC, Triage
+- [#3662](https://github.com/flipperdevices/flipperzero-firmware/issues/3662): **Shareable id** (by @robot-penguin34, 2024-05-23)
+  - Labels: NFC, Sub-GHz, Core+Services
+- [#3667](https://github.com/flipperdevices/flipperzero-firmware/issues/3667): **Feature NFC File Browser improved navigation** (by @quarky42, 2024-05-27)
+  - Labels: Feature Request, Core+Services
+- [#3677](https://github.com/flipperdevices/flipperzero-firmware/issues/3677): **A JavaScript module for handling a button press** (by @tlhunter, 2024-05-31)
+  - Labels: Feature Request, JS
+- [#3678](https://github.com/flipperdevices/flipperzero-firmware/issues/3678): **a JavaScript API for loading and drawing from a spritesheet** (by @tlhunter, 2024-05-31)
+  - Labels: Feature Request, JS
+- [#3687](https://github.com/flipperdevices/flipperzero-firmware/issues/3687): **125kHz fob not read / Protocol implementation?** (by @WilliamHF, 2024-06-05)
+  - Labels: Feature Request, RFID 125kHz
+- [#3704](https://github.com/flipperdevices/flipperzero-firmware/issues/3704): **IL region, sub-ghz missing allowed frequencies** (by @ypelech, 2024-06-12)
+  - Labels: Feature Request, Sub-GHz
+- [#3752](https://github.com/flipperdevices/flipperzero-firmware/issues/3752): **LFRFID: Indala E9 Support** (by @vineet4183, 2024-07-04)
+  - Labels: Feature Request, RFID 125kHz
+- [#3755](https://github.com/flipperdevices/flipperzero-firmware/issues/3755): **CC1101: Impossible to send a long preamble** (by @krzys-h, 2024-07-05)
+  - Labels: Sub-GHz, Bug
+- [#3756](https://github.com/flipperdevices/flipperzero-firmware/issues/3756): **Flipper crashes when continuously opening and closing the Passport screen** (by @CookiePLMonster, 2024-07-05)
+  - Labels: Bug, Core+Services
+- [#3772](https://github.com/flipperdevices/flipperzero-firmware/issues/3772): **MIFARE Ultralight C hex dump shows bogus data for locked pages** (by @supersat, 2024-07-09)
+  - Labels: NFC, UI, Triage
+- [#3778](https://github.com/flipperdevices/flipperzero-firmware/issues/3778): **Support multiple devices for BT remote** (by @Kami-no, 2024-07-10)
+  - Labels: Feature Request, Bluetooth
+- [#3818](https://github.com/flipperdevices/flipperzero-firmware/issues/3818): **T5577 Feature Request - dump / restore / compare feature** (by @amalg, 2024-07-31)
+  - Labels: Feature Request, RFID 125kHz
+- [#3821](https://github.com/flipperdevices/flipperzero-firmware/issues/3821): **RFID Read problem ** (by @domthomas-dev, 2024-08-03)
+  - Labels: Feature Request, RFID 125kHz
+- [#3825](https://github.com/flipperdevices/flipperzero-firmware/issues/3825): **C++ Breakpoints not hit** (by @janwiesemann, 2024-08-07)
+  - Labels: Build System & Scripts, Core+Services
+- [#3833](https://github.com/flipperdevices/flipperzero-firmware/issues/3833): **JS - Token reading** (by @Tomi2965, 2024-08-09)
+  - Labels: Feature Request, JS
+- [#3835](https://github.com/flipperdevices/flipperzero-firmware/issues/3835): **Attempting to read DESFire Card causes `furi_check()` crash** (by @5aji, 2024-08-11)
+  - Labels: NFC, Bug
+- [#3848](https://github.com/flipperdevices/flipperzero-firmware/issues/3848): **MIFARE Classic 1K EV1 is recognized as 1K, 16 sectors/32 keys** (by @noproto, 2024-08-20)
+  - Labels: NFC, Bug
+- [#3853](https://github.com/flipperdevices/flipperzero-firmware/issues/3853): **Reading an emulated Amiibo causes Flipper Zero to crash using NFC read but works using NFC Read specific card type** (by @ukscone, 2024-08-24)
+  - Labels: NFC, Triage
+- [#3867](https://github.com/flipperdevices/flipperzero-firmware/issues/3867): **Flipper misidentifies Visonic_Powecode alarm signal as Dickert_MAHS.** (by @Hamika20, 2024-09-02)
+  - Labels: Sub-GHz, Bug
+- [#3870](https://github.com/flipperdevices/flipperzero-firmware/issues/3870): **RFID not detecting some card types that other devices detect (e.g. Keysy) ** (by @PsiPhiTheta, 2024-09-03)
+  - Labels: RFID 125kHz, Bug
+- [#3876](https://github.com/flipperdevices/flipperzero-firmware/issues/3876): **Mouse Clicker Should have a "0" value setting for "as fast as possible"** (by @austeregrim, 2024-09-05)
+  - Labels: Feature Request, USB, Core+Services
+- [#3877](https://github.com/flipperdevices/flipperzero-firmware/issues/3877): **Less granular value selection in Bluetooth HID Mouse Clicker** (by @austeregrim, 2024-09-05)
+  - Labels: Feature Request, USB, Applications
+- [#3883](https://github.com/flipperdevices/flipperzero-firmware/issues/3883): **Blackmagic: Warning upon attaching to Flipper FW** (by @CookiePLMonster, 2024-09-07)
+  - Labels: Build System & Scripts, Triage
+- [#3884](https://github.com/flipperdevices/flipperzero-firmware/issues/3884): **Blackmagic: Reset/Reset Device don't work if execution is suspended on `furi_check()`** (by @CookiePLMonster, 2024-09-07)
+  - Labels: Build System & Scripts, Triage
+- [#3898](https://github.com/flipperdevices/flipperzero-firmware/issues/3898): **Universal Remote Feature - Enhancement Request** (by @HeIp, 2024-09-14)
+  - Labels: Feature Request, Infrared
+- [#3907](https://github.com/flipperdevices/flipperzero-firmware/issues/3907): **NFC Read does not identify MF Ultralight card - OFW 1.01** (by @kwjw3d, 2024-09-17)
+  - Labels: NFC, Triage
+- [#3910](https://github.com/flipperdevices/flipperzero-firmware/issues/3910): **`mbedtls.cfg.h` is not accessible when using local SDKs via uFBT** (by @CookiePLMonster, 2024-09-18)
+  - Labels: Bug, Build System & Scripts
+- [#3911](https://github.com/flipperdevices/flipperzero-firmware/issues/3911): **NFC Emulation Not Working Since 0.94.1** (by @S4RP1NG0, 2024-09-19)
+  - Labels: NFC, Bug
+- [#3913](https://github.com/flipperdevices/flipperzero-firmware/issues/3913): **Consider enabling C++23 and C23** (by @CookiePLMonster, 2024-09-20)
+  - Labels: Feature Request, Build System & Scripts
+- [#3938](https://github.com/flipperdevices/flipperzero-firmware/issues/3938): **[Sub-Ghz] Request support for Sherlotronics 403.55Mhz Transmitter** (by @Axolotl5903, 2024-10-11)
+  - Labels: Feature Request, Sub-GHz
+- [#3939](https://github.com/flipperdevices/flipperzero-firmware/issues/3939): **readKeyState function for badusb mjs module** (by @mantacid, 2024-10-11)
+  - Labels: Feature Request, JS
+- [#3981](https://github.com/flipperdevices/flipperzero-firmware/issues/3981): **Show alarm icon in status bar if alarm set** (by @j-lakeman, 2024-11-01)
+  - Labels: New Feature, Core+Services
+- [#3984](https://github.com/flipperdevices/flipperzero-firmware/issues/3984): **RFID Read problem** (by @vilmar-hillow, 2024-11-02)
+  - Labels: Feature Request, RFID 125kHz
+- [#3994](https://github.com/flipperdevices/flipperzero-firmware/issues/3994): **Clock & Alarm - lot of improvements needed** (by @Tomi2965, 2024-11-08)
+  - Labels: Feature Request, Core+Services
+- [#4002](https://github.com/flipperdevices/flipperzero-firmware/issues/4002): **RFE: Cannot write NFC-V tag** (by @marcmerlin, 2024-11-13)
+  - Labels: Feature Request, NFC
+- [#4007](https://github.com/flipperdevices/flipperzero-firmware/issues/4007): **universal IR** (by @ddddddddggfekzurkj, 2024-11-18)
+  - Labels: Feature Request, Infrared
+- [#4011](https://github.com/flipperdevices/flipperzero-firmware/issues/4011): **change Bluetooth / device name** (by @j-lakeman, 2024-11-21)
+  - Labels: Feature Request, Bluetooth
+- [#4012](https://github.com/flipperdevices/flipperzero-firmware/issues/4012): **Flipper Zero Mifare Plus 2K support (SL1 ONLY)** (by @Overc1ocker, 2024-11-22)
+  - Labels: Feature Request, NFC
+- [#4016](https://github.com/flipperdevices/flipperzero-firmware/issues/4016): **BadUSB F13-F24 keys support not functional** (by @jezh42, 2024-11-25)
+  - Labels: Feature Request, USB
+- [#4026](https://github.com/flipperdevices/flipperzero-firmware/issues/4026): **DESFire Light shows as unknown** (by @Bricolas, 2024-12-05)
+  - Labels: Feature Request, NFC
+- [#4037](https://github.com/flipperdevices/flipperzero-firmware/issues/4037): **Feature Request: Crontab** (by @jblanked, 2024-12-18)
+  - Labels: Feature Request, Core+Services
+- [#4063](https://github.com/flipperdevices/flipperzero-firmware/issues/4063): **RFID card not recognized** (by @Koopabro, 2025-01-07)
+  - Labels: Feature Request, RFID 125kHz
+- [#4072](https://github.com/flipperdevices/flipperzero-firmware/issues/4072): **Bad USB feature ignores keyboard layout setting (DE-CH)** (by @ThWunderlin, 2025-01-18)
+  - Labels: USB, Bug
+- [#4073](https://github.com/flipperdevices/flipperzero-firmware/issues/4073): **Crash with RCP app** (by @gaellalire, 2025-01-18)
+  - Labels: Bug, Core+Services
+- [#4079](https://github.com/flipperdevices/flipperzero-firmware/issues/4079): **Export BLE buffers in SKD** (by @loftyinclination, 2025-01-24)
+  - Labels: Feature Request, Core+Services, Bluetooth
+- [#4086](https://github.com/flipperdevices/flipperzero-firmware/issues/4086): **Region Mhz locks are incorrect for country code IM** (by @omalmighty, 2025-01-29)
+  - Labels: Sub-GHz
+- [#4089](https://github.com/flipperdevices/flipperzero-firmware/issues/4089): **Bug in Manual Read: effects slix nfc, possibly others** (by @FOSSBOSS, 2025-01-31)
+  - Labels: NFC, Triage
+- [#4104](https://github.com/flipperdevices/flipperzero-firmware/issues/4104): **Question regarding (non)consistency of blocking/internal animation manifests** (by @Kuronons, 2025-02-08)
+  - Labels: Documentation
+- [#4106](https://github.com/flipperdevices/flipperzero-firmware/issues/4106): **NFC Reading Issue with ISO 14443-3A Mifare Ultralight Card** (by @suaveolent, 2025-02-12)
+  - Labels: Feature Request, NFC
+- [#4108](https://github.com/flipperdevices/flipperzero-firmware/issues/4108): **NFC bus fault** (by @foXaCe, 2025-02-13)
+  - Labels: NFC, Bug
+- [#4130](https://github.com/flipperdevices/flipperzero-firmware/issues/4130): **Hook for Favorites menu** (by @leedave, 2025-02-26)
+  - Labels: Feature Request, Core+Services
+- [#4138](https://github.com/flipperdevices/flipperzero-firmware/issues/4138): **Add two BART Stations to Clipper Database** (by @Davis-P0, 2025-03-04)
+  - Labels: Feature Request, NFC
+- [#4148](https://github.com/flipperdevices/flipperzero-firmware/issues/4148): **BadUSB script runs too fast for notepad.exe on Windows 11** (by @ase1590, 2025-03-12)
+  - Labels: Triage
+- [#4152](https://github.com/flipperdevices/flipperzero-firmware/issues/4152): **I2C Slave mode** (by @TheSainEyereg, 2025-03-18)
+  - Labels: Feature Request, Core+Services
+- [#4162](https://github.com/flipperdevices/flipperzero-firmware/issues/4162): **Connecting as USB HID keyboard cannot read state of keyboard LEDs (CapsLock/NumLock/ScrollLock)** (by @maxplank, 2025-03-26)
+  - Labels: USB, Triage
+- [#4194](https://github.com/flipperdevices/flipperzero-firmware/issues/4194): **Technical Specification for Flipper Zero Mifare Classic 1K Enhancement** (by @x133t, 2025-04-19)
+  - Labels: NFC, Triage
+- [#4196](https://github.com/flipperdevices/flipperzero-firmware/issues/4196): **Technical Specification: NFC Tag Information Application for Flipper Zero** (by @x133t, 2025-04-19)
+  - Labels: NFC, Triage
+- [#4200](https://github.com/flipperdevices/flipperzero-firmware/issues/4200): **Enhance SubGhz with protocol command cycling** (by @Nvidiacerv, 2025-04-21)
+  - Labels: Feature Request, Sub-GHz
+- [#4209](https://github.com/flipperdevices/flipperzero-firmware/issues/4209): **[NFC] Incorrect mapping of Ultralight C in memory** (by @mishamyte, 2025-05-02)
+  - Labels: NFC, Bug
+- [#4214](https://github.com/flipperdevices/flipperzero-firmware/issues/4214): **furi_hal_hid_get_led_state() returns 0 regardless of keyboard state** (by @mantacid, 2025-05-05)
+  - Labels: JS, Triage
+- [#4218](https://github.com/flipperdevices/flipperzero-firmware/issues/4218): **[Buetooth] Why is the extra beacon size limited to 31?** (by @steam3d, 2025-05-08)
+  - Labels: Feature Request, Bluetooth
+- [#4247](https://github.com/flipperdevices/flipperzero-firmware/issues/4247): **NFC files not syncing via Bluetooth from Flipper to Android app (v1.8)** (by @KevinLiebergen, 2025-07-03)
+  - Labels: Bluetooth, Triage
+- [#4248](https://github.com/flipperdevices/flipperzero-firmware/issues/4248): **Inconsistent file path syntax in CLI** (by @Stichoza, 2025-07-11)
+  - Labels: Backlog, Bug, Core+Services
+- [#4249](https://github.com/flipperdevices/flipperzero-firmware/issues/4249): **Reading NFC card while connected via USB to a computer and to qFlipper leads to a OOM Crash** (by @hac-v, 2025-07-11)
+  - Labels: NFC, Triage
+- [#4250](https://github.com/flipperdevices/flipperzero-firmware/issues/4250): **Add ability to verify written tags/buttons** (by @eblis, 2025-07-17)
+  - Labels: Feature Request
+- [#4253](https://github.com/flipperdevices/flipperzero-firmware/issues/4253): **Adding a JS command to directly exit the application** (by @Zakrzewiaczek, 2025-07-27)
+  - Labels: Feature Request, JS
+- [#4258](https://github.com/flipperdevices/flipperzero-firmware/issues/4258): **Internal GDB error when trying to flash firmware using wifi devboard** (by @MatthewTromp, 2025-07-31)
+  - Labels: Triage
+- [#4262](https://github.com/flipperdevices/flipperzero-firmware/issues/4262): **Error while building firmware** (by @Rel0s, 2025-08-13)
+  - Labels: Triage
+- [#4263](https://github.com/flipperdevices/flipperzero-firmware/issues/4263): **Weather station: support for LaCrosse TX141-BV3** (by @onepointfive-REAL, 2025-08-13)
+  - Labels: Feature Request, Sub-GHz
+- [#4269](https://github.com/flipperdevices/flipperzero-firmware/issues/4269): **Support non-standard Indala RFID fob** (by @asportnoy, 2025-08-28)
+  - Labels: RFID 125kHz, Triage
+- [#4272](https://github.com/flipperdevices/flipperzero-firmware/issues/4272): **При попытке подключить модуль "flipper" в js-скрипте ошибка** (by @arduinotech, 2025-09-09)
+- [#4275](https://github.com/flipperdevices/flipperzero-firmware/issues/4275): **RFID Pet-animal** (by @MSmit715, 2025-09-12)
+  - Labels: RFID 125kHz, Triage
+- [#4276](https://github.com/flipperdevices/flipperzero-firmware/issues/4276): **RFID keyfob** (by @MSmit715, 2025-09-12)
+  - Labels: RFID 125kHz, Triage
+- [#4281](https://github.com/flipperdevices/flipperzero-firmware/issues/4281): **[mbedtls] Add ECDH** (by @bettse, 2025-10-02)
+  - Labels: Feature Request, Core+Services
+- [#4289](https://github.com/flipperdevices/flipperzero-firmware/issues/4289): **Same bag as cards #2218** (by @fishboW1, 2025-10-05)
+- [#4300](https://github.com/flipperdevices/flipperzero-firmware/issues/4300): **NFC app refuses to write NDEF after tag was password-protected, misinterprets AUTH0 / lock bytes for NTAG21x (tested on genuine NTAG216)** (by @TomHarkness, 2025-10-27)
+- [#4303](https://github.com/flipperdevices/flipperzero-firmware/issues/4303): **Freezing desktop animation** (by @Crudefern, 2025-10-30)
+- [#4307](https://github.com/flipperdevices/flipperzero-firmware/issues/4307): **How to use sub-GHz** (by @Inkpro436, 2025-11-08)
+- [#4310](https://github.com/flipperdevices/flipperzero-firmware/issues/4310): **Incorrect Sub-GHz region lock for BH (Bahrain) — 433 MHz should be permitted** (by @el7ommed, 2025-11-20)
+- [#4314](https://github.com/flipperdevices/flipperzero-firmware/issues/4314): **Reading saved Felica Standart emulation by another FZ leads to its crash** (by @RebornedBrain, 2025-12-01)
+- [#4317](https://github.com/flipperdevices/flipperzero-firmware/issues/4317): **"System Protobuf Version timeout"** (by @zatcx, 2025-12-18)
+- [#4321](https://github.com/flipperdevices/flipperzero-firmware/issues/4321): **NTAG215 emulation enables password auth and config lock too early** (by @Firefox2100, 2025-12-25)
+- [#4322](https://github.com/flipperdevices/flipperzero-firmware/issues/4322): **Javascript - Infrared Module** (by @LuisMayo, 2025-12-27)


### PR DESCRIPTION
Automatically imported 162 open issues from upstream Flipper Zero firmware repository for tracking purposes.